### PR TITLE
feat: 글감 제목받기, 글감 단어 받기

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,6 +3,7 @@ import { PrismaModule } from './prisma/prisma.module';
 import { ConfigModule } from '@nestjs/config';
 import { AuthModule } from './auth/auth.module';
 import { UserModule } from './user/user.module';
+import { InspirationModule } from './inspiration/inspiration.module';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { UserModule } from './user/user.module';
     }),
     AuthModule,
     UserModule,
+    InspirationModule,
   ],
 })
 export class AppModule {}

--- a/src/inspiration/dto/response/index.ts
+++ b/src/inspiration/dto/response/index.ts
@@ -1,0 +1,2 @@
+export { TitleDto } from './title.dto';
+export { WordDto } from './word.dto';

--- a/src/inspiration/dto/response/title.dto.ts
+++ b/src/inspiration/dto/response/title.dto.ts
@@ -1,0 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class TitleDto {
+  @ApiProperty()
+  title: string;
+}

--- a/src/inspiration/dto/response/word.dto.ts
+++ b/src/inspiration/dto/response/word.dto.ts
@@ -1,0 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class WordDto {
+  @ApiProperty()
+  word: string;
+}

--- a/src/inspiration/inspiration.controller.ts
+++ b/src/inspiration/inspiration.controller.ts
@@ -1,0 +1,37 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { JwtGuard } from 'src/auth/guards';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+import { InspirationService } from './inspiration.service';
+import { TitleDto, WordDto } from './dto/response';
+
+@ApiTags('inspiration')
+@ApiBearerAuth()
+@Controller('inspiration')
+export class InspirationController {
+  constructor(private readonly inspirationService: InspirationService) {}
+
+  @ApiOperation({
+    summary: '제목 글감 받기 - 현재는 하드코딩. 기획이 확정나면 추가 구현 예정',
+  })
+  @ApiResponse({ status: 200, type: TitleDto })
+  @Get('title')
+  @UseGuards(JwtGuard)
+  async getTitle() {
+    return this.inspirationService.getTitle();
+  }
+
+  @ApiOperation({
+    summary: '단어 글감 받기 - 현재는 하드코딩. 기획이 확정나면 추가 구현 예정',
+  })
+  @ApiResponse({ status: 200, type: WordDto })
+  @Get('word')
+  @UseGuards(JwtGuard)
+  async getWord() {
+    return this.inspirationService.getWord();
+  }
+}

--- a/src/inspiration/inspiration.module.ts
+++ b/src/inspiration/inspiration.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { InspirationController } from './inspiration.controller';
+import { InspirationService } from './inspiration.service';
+
+@Module({
+  controllers: [InspirationController],
+  providers: [InspirationService],
+})
+export class InspirationModule {}

--- a/src/inspiration/inspiration.service.ts
+++ b/src/inspiration/inspiration.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class InspirationService {
+  async getTitle() {
+    return {
+      title: '오늘의 글감',
+    };
+  }
+
+  async getWord() {
+    return {
+      word: '오늘의 단어',
+    };
+  }
+}


### PR DESCRIPTION
- GET /inspiration/title
- GET /inspiration/word

글감 종류에 따라 반환값이 다르기때문에 query string으로 한 엔드포인트에서 받기보단 엔드포인트를 나눠서 Swagger 가독성 증가
현재 "글감" 이라는 기획이 완성된게 아니기 때문에 하드코딩
글감 주제는 4가지 다 동일한 주제인지, 글감을 데이터베이스에 모아두고 매일매일 랜덤으로 뿌리는건지 아니면 매일 새로운 글감이 데이터베이스에 insert 되는지, 또 글감 데이터를 어떻게 생성할지에 대해 기획이 완성되면 구체적인 로직 구현할 예정