### PR TITLE
탈고 시 수정 전의 title도 optional로 저장

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,6 +35,7 @@ model Poem {
   isRecorded      Boolean
   status          String
   originalContent String?
+  originalTitle   String?
   createdAt       DateTime @default(now())
 
   authorId String

--- a/src/poem/dto/request/create-poem.dto.ts
+++ b/src/poem/dto/request/create-poem.dto.ts
@@ -42,6 +42,15 @@ export class CreatePoemDto {
   originalContent?: string;
 
   @ApiProperty({
+    description: 'AI가 수정하기 전의 원본 시 제목',
+    required: false,
+    nullable: true,
+  })
+  @IsOptional()
+  @IsString()
+  originalTitle?: string;
+
+  @ApiProperty({
     type: 'string',
     format: 'binary',
     required: false,

--- a/src/poem/poem.repository.ts
+++ b/src/poem/poem.repository.ts
@@ -14,6 +14,7 @@ export class PoemRepository {
       },
       omit: {
         originalContent: true,
+        originalTitle: true,
       },
     });
   }

--- a/src/poem/poem.service.ts
+++ b/src/poem/poem.service.ts
@@ -29,6 +29,7 @@ export class PoemService {
       textFont: createPoemInput.textFont,
       isRecorded: createPoemInput.audioFile ? true : false,
       originalContent: createPoemInput.originalContent ?? null,
+      originalTitle: createPoemInput.originalTitle ?? null,
       status: '교정중',
     };
 
@@ -57,6 +58,7 @@ export type CreatePoemInput = {
   textSize: number;
   textFont: string;
   originalContent?: string;
+  originalTitle?: string;
   audioFile?: Express.Multer.File;
 };
 


### PR DESCRIPTION
- 기존엔 AI가 수정하기 전 시의 내용만 받음
- 이젠 AI가 시의 제목도 바꿀 수 있어서 제목도 optional로 받고 저장