### PR TITLE
AuthAPI E2E Test 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 package-lock.json
 rest-client/
 migrations/
+env/

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { PoemModule } from './poem/poem.module';
 import { AwsModule } from './aws/aws.module';
 import { EmotionModule } from './emotion/emotion.module';
 import { TagModule } from './tag/tag.module';
+import { PipesModule } from './common/pipes/pipes.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { TagModule } from './tag/tag.module';
       expandVariables: true,
       cache: true,
     }),
+    PipesModule,
     AuthModule,
     UserModule,
     InspirationModule,

--- a/src/common/pipes/pipes.module.ts
+++ b/src/common/pipes/pipes.module.ts
@@ -1,0 +1,21 @@
+import { Module, Provider, ValidationPipe } from '@nestjs/common';
+import { APP_PIPE } from '@nestjs/core';
+
+const pipes: Provider[] = [
+  {
+    provide: APP_PIPE,
+    useValue: new ValidationPipe({
+      whitelist: true,
+      transform: true,
+      transformOptions: {
+        enableImplicitConversion: true,
+      },
+      enableDebugMessages: true,
+    }),
+  },
+];
+
+@Module({
+  providers: [...pipes],
+})
+export class PipesModule {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,17 +12,6 @@ async function bootstrap() {
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
   });
 
-  app.useGlobalPipes(
-    new ValidationPipe({
-      whitelist: true,
-      transform: true,
-      transformOptions: {
-        enableImplicitConversion: true,
-      },
-      enableDebugMessages: true,
-    }),
-  );
-
   // swagger
   const config = new DocumentBuilder()
     .setTitle('to_morrow API')

--- a/test/e2e/auth.e2e-spec.ts
+++ b/test/e2e/auth.e2e-spec.ts
@@ -1,0 +1,141 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from 'src/app.module';
+import { ValidationPipe } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { AuthService } from 'src/auth/auth.service';
+
+describe('Auth (e2e)', () => {
+  let app: INestApplication;
+  let prisma: PrismaService;
+  let authService: AuthService;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        transform: true,
+        transformOptions: {
+          enableImplicitConversion: true,
+        },
+        enableDebugMessages: true,
+      }),
+    );
+    await app.init();
+
+    prisma = moduleFixture.get<PrismaService>(PrismaService);
+    authService = moduleFixture.get<AuthService>(AuthService);
+
+    jest.spyOn(authService, 'getGoogleProfile').mockResolvedValue({
+      id: 'test-id',
+      email: 'test@test.com',
+      picture: 'https://picture.com',
+      verified_email: true,
+    });
+  });
+
+  afterEach(async () => {
+    await prisma.user.deleteMany();
+  });
+
+  describe('POST /auth/signup - 회원가입', () => {
+    it('필명에 공백문자가 들어가면 400을 반환한다', async () => {
+      //given
+      const signupDto = {
+        provider: 'GOOGLE',
+        providerAccessToken: 'test-token',
+        name: 'test name',
+      };
+
+      //when
+      const response = await request(app.getHttpServer())
+        .post('/auth/signup')
+        .send(signupDto);
+
+      //then
+      expect(response.status).toBe(400);
+    });
+
+    it('필명에 밑줄과 하이픈이 아닌 특수문자가 들어가면 400을 반환한다', async () => {
+      //given
+      const signupDto = {
+        provider: 'GOOGLE',
+        providerAccessToken: 'test-token',
+        name: 'test!name',
+      };
+
+      //when
+      const response = await request(app.getHttpServer())
+        .post('/auth/signup')
+        .send(signupDto);
+
+      //then
+      expect(response.status).toBe(400);
+    });
+
+    it('필명이 2글자 미만일때 400을 반환한다', async () => {
+      //given
+      const signupDto = {
+        provider: 'GOOGLE',
+        providerAccessToken: 'test-token',
+        name: 't',
+      };
+
+      //when
+      const response = await request(app.getHttpServer())
+        .post('/auth/signup')
+        .send(signupDto);
+
+      //then
+      expect(response.status).toBe(400);
+    });
+
+    it('필명이 14글자 초과일때 400을 반환한다', async () => {
+      //given
+      const signupDto = {
+        provider: 'GOOGLE',
+        providerAccessToken: 'test-token',
+        name: 'testtesttesttest',
+      };
+
+      //when
+      const response = await request(app.getHttpServer())
+        .post('/auth/signup')
+        .send(signupDto);
+
+      //then
+      expect(response.status).toBe(400);
+    });
+
+    it('회원가입이 정상적으로 이루어지면 201과 함께 토큰을 반환하며 데이터베이스에 유저가 생성된다', async () => {
+      //given
+      const signupDto = {
+        provider: 'GOOGLE',
+        providerAccessToken: 'test-token',
+        name: 'test-name',
+      };
+
+      //when
+      const response = await request(app.getHttpServer())
+        .post('/auth/signup')
+        .send(signupDto);
+
+      //then
+      expect(response.status).toBe(201);
+      expect(response.body.accessToken).toBeDefined();
+
+      const user = await prisma.user.findFirst({
+        where: {
+          name: signupDto.name,
+        },
+      });
+      expect(user!.name).toBe(signupDto.name);
+    });
+  });
+});

--- a/test/e2e/auth.e2e-spec.ts
+++ b/test/e2e/auth.e2e-spec.ts
@@ -46,87 +46,87 @@ describe('Auth (e2e)', () => {
 
   describe('POST /auth/signup - 회원가입', () => {
     it('필명에 공백문자가 들어가면 400을 반환한다', async () => {
-      //given
+      // given
       const signupDto = {
         provider: 'GOOGLE',
         providerAccessToken: 'test-token',
         name: 'test name',
       };
 
-      //when
+      // when
       const response = await request(app.getHttpServer())
         .post('/auth/signup')
         .send(signupDto);
 
-      //then
+      // then
       expect(response.status).toBe(400);
     });
 
     it('필명에 밑줄과 하이픈이 아닌 특수문자가 들어가면 400을 반환한다', async () => {
-      //given
+      // given
       const signupDto = {
         provider: 'GOOGLE',
         providerAccessToken: 'test-token',
         name: 'test!name',
       };
 
-      //when
+      // when
       const response = await request(app.getHttpServer())
         .post('/auth/signup')
         .send(signupDto);
 
-      //then
+      // then
       expect(response.status).toBe(400);
     });
 
     it('필명이 2글자 미만일때 400을 반환한다', async () => {
-      //given
+      // given
       const signupDto = {
         provider: 'GOOGLE',
         providerAccessToken: 'test-token',
         name: 't',
       };
 
-      //when
+      // when
       const response = await request(app.getHttpServer())
         .post('/auth/signup')
         .send(signupDto);
 
-      //then
+      // then
       expect(response.status).toBe(400);
     });
 
     it('필명이 14글자 초과일때 400을 반환한다', async () => {
-      //given
+      // given
       const signupDto = {
         provider: 'GOOGLE',
         providerAccessToken: 'test-token',
         name: 'testtesttesttest',
       };
 
-      //when
+      // when
       const response = await request(app.getHttpServer())
         .post('/auth/signup')
         .send(signupDto);
 
-      //then
+      // then
       expect(response.status).toBe(400);
     });
 
     it('회원가입이 정상적으로 이루어지면 201과 함께 토큰을 반환하며 데이터베이스에 유저가 생성된다', async () => {
-      //given
+      // given
       const signupDto = {
         provider: 'GOOGLE',
         providerAccessToken: 'test-token',
         name: 'test-name',
       };
 
-      //when
+      // when
       const response = await request(app.getHttpServer())
         .post('/auth/signup')
         .send(signupDto);
 
-      //then
+      // then
       expect(response.status).toBe(201);
       expect(response.body.accessToken).toBeDefined();
 
@@ -136,6 +136,65 @@ describe('Auth (e2e)', () => {
         },
       });
       expect(user!.name).toBe(signupDto.name);
+    });
+  });
+
+  describe('POST /auth/login - 로그인', () => {
+    it('존재하지 않는 유저일 경우 404를 반환한다', async () => {
+      // given
+      const loginDto = {
+        provider: 'GOOGLE',
+        providerAccessToken: 'test-token',
+      };
+
+      // when
+      const response = await request(app.getHttpServer())
+        .post('/auth/login')
+        .send(loginDto);
+
+      // then
+      expect(response.status).toBe(404);
+      expect(response.body.message).toBe('user not found');
+    });
+
+    it('존재하는 유저일 경우 200과 함께 accessToken을 반환한다', async () => {
+      // given
+      const user = await prisma.user.create({
+        data: {
+          provider: 'GOOGLE',
+          providerId: 'test-id',
+          name: 'test-name',
+        },
+      });
+      const loginDto = {
+        provider: 'GOOGLE',
+        providerAccessToken: 'test-token',
+      };
+
+      // when
+      const response = await request(app.getHttpServer())
+        .post('/auth/login')
+        .send(loginDto);
+
+      // then
+      expect(response.status).toBe(200);
+      expect(response.body.accessToken).toBeDefined();
+    });
+
+    it('provider에 GOOGLE과 APPLE이 아닌 값이 들어오면 400을 반환한다', async () => {
+      // given
+      const loginDto = {
+        provider: 'KAKAO',
+        providerAccessToken: 'test-token',
+      };
+
+      // when
+      const response = await request(app.getHttpServer())
+        .post('/auth/login')
+        .send(loginDto);
+
+      // then
+      expect(response.status).toBe(400);
     });
   });
 });

--- a/test/e2e/auth.e2e-spec.ts
+++ b/test/e2e/auth.e2e-spec.ts
@@ -17,16 +17,6 @@ describe('Auth (e2e)', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
-    app.useGlobalPipes(
-      new ValidationPipe({
-        whitelist: true,
-        transform: true,
-        transformOptions: {
-          enableImplicitConversion: true,
-        },
-        enableDebugMessages: true,
-      }),
-    );
     await app.init();
 
     prisma = moduleFixture.get<PrismaService>(PrismaService);

--- a/test/e2e/poem.e2e-spec.ts
+++ b/test/e2e/poem.e2e-spec.ts
@@ -31,7 +31,7 @@ describe('Poem (e2e)', () => {
     });
   });
 
-  beforeEach(async () => {
+  afterEach(async () => {
     await prisma.scrap.deleteMany();
     await prisma.poem.deleteMany();
     await prisma.user.deleteMany();


### PR DESCRIPTION
## 🏷️ 연관 이슈

- close #32 

## ✨ 작업 내용
- POST /auth/signup - 회원가입
  - 필명에 공백문자가 들어가면 400을 반환한다
  - 필명에 밑줄과 하이픈이 아닌 특수문자가 들어가면 400을 반환한다
  - 필명이 2글자 미만일때 400을 반환한다
  - 필명이 14글자 초과일때 400을 반환한다
  - 회원가입이 정상적으로 이루어지면 201과 함께 토큰을 반환하며 데이터베이스에 유저가 생성된다
- POST /auth/login - 로그인
  - 존재하지 않는 유저일 경우 404를 반환한다
  - 존재하는 유저일 경우 200과 함께 accessToken을 반환한다
  - provider에 GOOGLE과 APPLE이 아닌 값이 들어오면 400을 반환한다
- beforeEach Clear -> afterEach Clear로 변경