### PR TITLE
PATCH /poems/tag - 시 태그 변경 E2E 테스트

### DIFF
--- a/src/poem/dto/request/update-tag.dto.ts
+++ b/src/poem/dto/request/update-tag.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsArray, IsString, IsEnum } from 'class-validator';
+import { IsString, IsEnum } from 'class-validator';
 import { themes, interactions } from 'src/constants/tags';
 
 export class UpdateTagDto {
@@ -8,22 +8,18 @@ export class UpdateTagDto {
   readonly title: string;
 
   @ApiProperty()
-  @IsArray()
   @IsEnum(themes, { each: true })
   readonly beforeThemes: string[];
 
   @ApiProperty()
-  @IsArray()
   @IsEnum(interactions, { each: true })
   readonly beforeInteractions: string[];
 
   @ApiProperty()
-  @IsArray()
   @IsEnum(themes, { each: true })
   readonly afterThemes: string[];
 
   @ApiProperty()
-  @IsArray()
   @IsEnum(interactions, { each: true })
   readonly afterInteractions: string[];
 

--- a/src/poem/dto/request/update-tag.dto.ts
+++ b/src/poem/dto/request/update-tag.dto.ts
@@ -7,19 +7,19 @@ export class UpdateTagDto {
   @IsString()
   readonly title: string;
 
-  @ApiProperty({ enum: themes })
+  @ApiProperty({ isArray: true, enum: themes })
   @IsEnum(themes, { each: true })
   readonly beforeThemes: string[];
 
-  @ApiProperty({ enum: interactions })
+  @ApiProperty({ isArray: true, enum: interactions })
   @IsEnum(interactions, { each: true })
   readonly beforeInteractions: string[];
 
-  @ApiProperty({ enum: themes })
+  @ApiProperty({ isArray: true, enum: themes })
   @IsEnum(themes, { each: true })
   readonly afterThemes: string[];
 
-  @ApiProperty({ enum: interactions })
+  @ApiProperty({ isArray: true, enum: interactions })
   @IsEnum(interactions, { each: true })
   readonly afterInteractions: string[];
 

--- a/src/poem/dto/request/update-tag.dto.ts
+++ b/src/poem/dto/request/update-tag.dto.ts
@@ -7,19 +7,19 @@ export class UpdateTagDto {
   @IsString()
   readonly title: string;
 
-  @ApiProperty()
+  @ApiProperty({ enum: themes })
   @IsEnum(themes, { each: true })
   readonly beforeThemes: string[];
 
-  @ApiProperty()
+  @ApiProperty({ enum: interactions })
   @IsEnum(interactions, { each: true })
   readonly beforeInteractions: string[];
 
-  @ApiProperty()
+  @ApiProperty({ enum: themes })
   @IsEnum(themes, { each: true })
   readonly afterThemes: string[];
 
-  @ApiProperty()
+  @ApiProperty({ enum: interactions })
   @IsEnum(interactions, { each: true })
   readonly afterInteractions: string[];
 

--- a/src/poem/dto/request/update-tag.dto.ts
+++ b/src/poem/dto/request/update-tag.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsArray, IsString } from 'class-validator';
+import { IsArray, IsString, IsEnum } from 'class-validator';
+import { themes, interactions } from 'src/constants/tags';
 
 export class UpdateTagDto {
   @ApiProperty()
@@ -8,22 +9,22 @@ export class UpdateTagDto {
 
   @ApiProperty()
   @IsArray()
-  @IsString({ each: true })
+  @IsEnum(themes, { each: true })
   readonly beforeThemes: string[];
 
   @ApiProperty()
   @IsArray()
-  @IsString({ each: true })
+  @IsEnum(interactions, { each: true })
   readonly beforeInteractions: string[];
 
   @ApiProperty()
   @IsArray()
-  @IsString({ each: true })
+  @IsEnum(themes, { each: true })
   readonly afterThemes: string[];
 
   @ApiProperty()
   @IsArray()
-  @IsString({ each: true })
+  @IsEnum(interactions, { each: true })
   readonly afterInteractions: string[];
 
   @ApiProperty()


### PR DESCRIPTION
## 🏷️ 연관 이슈
- close #37 
## ✨ 작업 내용
- updateTag DTO에 서비스에서 미리 정의된 테마와 상호작용이 아닌 태그가 들어왔을 시 유효성검사 에러를 발생시키는 기능 추가
- PATCH /poems/tag - 시 태그 수정
  - 서비스에 정의된 테마와 상호작용이 아닌 태그를 입력하면 400 에러를 반환한다.
  - 시의 태그를 수정하면 시의 내용을 수정해서 반환한다.
  - LLM API 모킹해서 구현