### PR TITLE
업적 조회 기능 구현

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,12 +13,6 @@ enum Provider {
   APPLE
 }
 
-// 임시 업적입니다.
-enum AchievementName {
-  SCRAPKING
-  SCRAPQUEEN
-}
-
 model User {
   id         String   @id @default(uuid())
   provider   Provider
@@ -65,11 +59,11 @@ model Scrap {
 }
 
 model Achievement {
-  id          String          @id @default(uuid())
-  name        AchievementName
+  id          String   @id @default(uuid())
+  name        String
   icon        String
   description String
-  createdAt   DateTime        @default(now())
+  createdAt   DateTime @default(now())
 
   acquisitionUser       User[]
   achievementAcquistion AchievementAcquisition[]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -65,10 +65,11 @@ model Scrap {
 }
 
 model Achievement {
-  id        String          @id @default(uuid())
-  name      AchievementName
-  icon      String
-  createdAt DateTime        @default(now())
+  id          String          @id @default(uuid())
+  name        AchievementName
+  icon        String
+  description String
+  createdAt   DateTime        @default(now())
 
   acquisitionUser       User[]
   achievementAcquistion AchievementAcquisition[]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,9 +13,10 @@ enum Provider {
   APPLE
 }
 
-// SCRAPKING은 임시입니다.
+// 임시 업적입니다.
 enum AchievementName {
   SCRAPKING
+  SCRAPQUEEN
 }
 
 model User {

--- a/src/achievement/achievement.controller.ts
+++ b/src/achievement/achievement.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { AchievementService } from './achievement.service';
+import { JwtGuard } from '../auth/guards';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { AchievementsDto } from './dto/response';
+
+@ApiTags('achievements')
+@ApiBearerAuth()
+@UseGuards(JwtGuard)
+@Controller('achievements')
+export class AchievementController {
+  constructor(private readonly achievementService: AchievementService) {}
+
+  @ApiOperation({
+    summary: '모든 업적 조회',
+  })
+  @ApiResponse({ status: 200, type: [AchievementsDto] })
+  @Get()
+  async getAll() {
+    return await this.achievementService.getAll();
+  }
+}

--- a/src/achievement/achievement.controller.ts
+++ b/src/achievement/achievement.controller.ts
@@ -1,4 +1,10 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  ParseUUIDPipe,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 import { AchievementService } from './achievement.service';
 import { JwtGuard } from '../auth/guards';
 import {
@@ -24,5 +30,14 @@ export class AchievementController {
   @Get()
   async getAll() {
     return await this.achievementService.getAll();
+  }
+
+  @ApiOperation({
+    summary: '특정 회원이 획득한 모든 업적 조회',
+  })
+  @ApiResponse({ status: 200, type: [AchievementsDto] })
+  @Get('user')
+  async getAllByUserId(@Query('userId', ParseUUIDPipe) userId: string) {
+    return await this.achievementService.getAllByUserId(userId);
   }
 }

--- a/src/achievement/achievement.controller.ts
+++ b/src/achievement/achievement.controller.ts
@@ -15,6 +15,7 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { AchievementsDto } from './dto/response';
+import { CurrentUser } from '../common/decorators';
 
 @ApiTags('achievements')
 @ApiBearerAuth()
@@ -28,8 +29,8 @@ export class AchievementController {
   })
   @ApiResponse({ status: 200, type: [AchievementsDto] })
   @Get()
-  async getAll() {
-    return await this.achievementService.getAll();
+  async getAll(@CurrentUser() userId: string) {
+    return await this.achievementService.getAll(userId);
   }
 
   @ApiOperation({

--- a/src/achievement/achievement.module.ts
+++ b/src/achievement/achievement.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { AchievementService } from './achievement.service';
+import { AchievementController } from './achievement.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+import { AchievementRepository } from './achievement.repository';
+import { AchievementPrismaRepository } from './achievement.prisma.repository';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [AchievementController],
+  providers: [
+    AchievementService,
+    { provide: AchievementRepository, useClass: AchievementPrismaRepository },
+  ],
+})
+export class AchievementModule {}

--- a/src/achievement/achievement.prisma.repository.ts
+++ b/src/achievement/achievement.prisma.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Achievement, AchievementRepository } from './achievement.repository';
+import { AchievementRepository } from './achievement.repository';
 import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()

--- a/src/achievement/achievement.prisma.repository.ts
+++ b/src/achievement/achievement.prisma.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { AchievementRepository } from './achievement.repository';
+import { Achievement, AchievementRepository } from './achievement.repository';
 import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
@@ -12,5 +12,20 @@ export class AchievementPrismaRepository implements AchievementRepository {
         createdAt: true,
       },
     });
+  }
+
+  async findAllByUserId(userId: string) {
+    return await this.prisma.achievementAcquisition
+      .findMany({
+        where: { userId },
+        select: {
+          achievement: {
+            omit: {
+              createdAt: true,
+            },
+          },
+        },
+      })
+      .then((list) => list.map((data) => data.achievement));
   }
 }

--- a/src/achievement/achievement.prisma.repository.ts
+++ b/src/achievement/achievement.prisma.repository.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { AchievementRepository } from './achievement.repository';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class AchievementPrismaRepository implements AchievementRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAll() {
+    return await this.prisma.achievement.findMany({
+      omit: {
+        createdAt: true,
+      },
+    });
+  }
+}

--- a/src/achievement/achievement.repository.ts
+++ b/src/achievement/achievement.repository.ts
@@ -3,9 +3,9 @@ export interface AchievementRepository {
   findAllByUserId(userId: string): Promise<Achievement[]>;
 }
 
-export type AchievementName = 'SCRAPKING' | 'SCRAPQUEEN';
+type AchievementName = 'SCRAPKING' | 'SCRAPQUEEN';
 
-export type Achievement = {
+type Achievement = {
   id: string;
   name: AchievementName;
   icon: string;

--- a/src/achievement/achievement.repository.ts
+++ b/src/achievement/achievement.repository.ts
@@ -9,6 +9,7 @@ type Achievement = {
   id: string;
   name: AchievementName;
   icon: string;
+  description: string;
 };
 
 export const AchievementRepository = Symbol('AchievementRepository');

--- a/src/achievement/achievement.repository.ts
+++ b/src/achievement/achievement.repository.ts
@@ -3,11 +3,9 @@ export interface AchievementRepository {
   findAllByUserId(userId: string): Promise<Achievement[]>;
 }
 
-type AchievementName = 'SCRAPKING' | 'SCRAPQUEEN';
-
 type Achievement = {
   id: string;
-  name: AchievementName;
+  name: string;
   icon: string;
   description: string;
 };

--- a/src/achievement/achievement.repository.ts
+++ b/src/achievement/achievement.repository.ts
@@ -1,0 +1,13 @@
+export interface AchievementRepository {
+  findAll(): Promise<Achievement[]>;
+}
+
+export type AchievementName = 'SCRAPKING' | 'SCRAPQUEEN';
+
+export type Achievement = {
+  id: string;
+  name: AchievementName;
+  icon: string;
+};
+
+export const AchievementRepository = Symbol('AchievementRepository');

--- a/src/achievement/achievement.repository.ts
+++ b/src/achievement/achievement.repository.ts
@@ -1,5 +1,6 @@
 export interface AchievementRepository {
   findAll(): Promise<Achievement[]>;
+  findAllByUserId(userId: string): Promise<Achievement[]>;
 }
 
 export type AchievementName = 'SCRAPKING' | 'SCRAPQUEEN';

--- a/src/achievement/achievement.service.ts
+++ b/src/achievement/achievement.service.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { AchievementRepository } from './achievement.repository';
+import { Achievement } from './types';
 
 @Injectable()
 export class AchievementService {
@@ -8,12 +9,30 @@ export class AchievementService {
     private readonly achievementRepository: AchievementRepository,
   ) {}
 
-  async getAll() {
-    return await this.achievementRepository.findAll();
+  // TODO 회원 검색 구현하면, 존재하는 회원인지 검증 코드 추가.
+  async getAll(userId: string) {
+    const achievements = await this.achievementRepository.findAll();
+    const acquiredAchievements =
+      await this.achievementRepository.findAllByUserId(userId);
+
+    return this.checkAqusitionStatus(achievements, acquiredAchievements);
   }
 
   // TODO 회원 검색 구현하면, 존재하는 회원인지 검증 코드 추가.
   async getAllByUserId(userId: string) {
     return await this.achievementRepository.findAllByUserId(userId);
+  }
+
+  checkAqusitionStatus(
+    achievements: Achievement[],
+    acquiredAchievements: Achievement[],
+  ) {
+    const acquiredAchievementsIds = acquiredAchievements.map(
+      (achievement) => achievement.id,
+    );
+    return achievements.map((achievement) => ({
+      ...achievement,
+      isAquired: acquiredAchievementsIds.includes(achievement.id),
+    }));
   }
 }

--- a/src/achievement/achievement.service.ts
+++ b/src/achievement/achievement.service.ts
@@ -11,4 +11,9 @@ export class AchievementService {
   async getAll() {
     return await this.achievementRepository.findAll();
   }
+
+  // TODO 회원 검색 구현하면, 존재하는 회원인지 검증 코드 추가.
+  async getAllByUserId(userId: string) {
+    return await this.achievementRepository.findAllByUserId(userId);
+  }
 }

--- a/src/achievement/achievement.service.ts
+++ b/src/achievement/achievement.service.ts
@@ -1,0 +1,14 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { AchievementRepository } from './achievement.repository';
+
+@Injectable()
+export class AchievementService {
+  constructor(
+    @Inject(AchievementRepository)
+    private readonly achievementRepository: AchievementRepository,
+  ) {}
+
+  async getAll() {
+    return await this.achievementRepository.findAll();
+  }
+}

--- a/src/achievement/achievement.service.ts
+++ b/src/achievement/achievement.service.ts
@@ -15,7 +15,7 @@ export class AchievementService {
     const acquiredAchievements =
       await this.achievementRepository.findAllByUserId(userId);
 
-    return this.checkAqusitionStatus(achievements, acquiredAchievements);
+    return this.checkAcqusitionStatus(achievements, acquiredAchievements);
   }
 
   // TODO 회원 검색 구현하면, 존재하는 회원인지 검증 코드 추가.
@@ -23,7 +23,7 @@ export class AchievementService {
     return await this.achievementRepository.findAllByUserId(userId);
   }
 
-  checkAqusitionStatus(
+  checkAcqusitionStatus(
     achievements: Achievement[],
     acquiredAchievements: Achievement[],
   ) {

--- a/src/achievement/dto/response/achievements.dto.ts
+++ b/src/achievement/dto/response/achievements.dto.ts
@@ -1,15 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { AchievementName } from '../../types';
 
 export class AchievementsDto {
   @ApiProperty()
   readonly id: string;
 
-  @ApiProperty({
-    enum: ['SCRAPKING', 'SCRAPQUEEN'],
-    description: '칭호 명은 임시',
-  })
-  readonly name: AchievementName;
+  @ApiProperty()
+  readonly name: string;
 
   @ApiProperty({ description: '아이콘 URL' })
   readonly icon: string;

--- a/src/achievement/dto/response/achievements.dto.ts
+++ b/src/achievement/dto/response/achievements.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { AchievementName } from '../../achievement.repository';
+
+export class AchievementsDto {
+  @ApiProperty()
+  readonly id: string;
+
+  @ApiProperty({
+    enum: ['SCRAPKING', 'SCRAPQUEEN'],
+    description: '칭호 명은 임시',
+  })
+  readonly name: AchievementName;
+
+  @ApiProperty({ description: '아이콘 URL' })
+  readonly icon: string;
+}

--- a/src/achievement/dto/response/achievements.dto.ts
+++ b/src/achievement/dto/response/achievements.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { AchievementName } from '../../achievement.repository';
+import { AchievementName } from '../../types';
 
 export class AchievementsDto {
   @ApiProperty()
@@ -13,4 +13,7 @@ export class AchievementsDto {
 
   @ApiProperty({ description: '아이콘 URL' })
   readonly icon: string;
+
+  @ApiProperty({ description: '획득 여부' })
+  readonly isAquired: boolean;
 }

--- a/src/achievement/dto/response/achievements.dto.ts
+++ b/src/achievement/dto/response/achievements.dto.ts
@@ -14,6 +14,9 @@ export class AchievementsDto {
   @ApiProperty({ description: '아이콘 URL' })
   readonly icon: string;
 
+  @ApiProperty({ description: '획득 조건' })
+  readonly descrption: string;
+
   @ApiProperty({ description: '획득 여부' })
   readonly isAquired: boolean;
 }

--- a/src/achievement/dto/response/index.ts
+++ b/src/achievement/dto/response/index.ts
@@ -1,0 +1,1 @@
+export * from './achievements.dto';

--- a/src/achievement/types.ts
+++ b/src/achievement/types.ts
@@ -1,7 +1,5 @@
-export type AchievementName = 'SCRAPKING' | 'SCRAPQUEEN';
-
 export type Achievement = {
   id: string;
-  name: AchievementName;
+  name: string;
   icon: string;
 };

--- a/src/achievement/types.ts
+++ b/src/achievement/types.ts
@@ -1,0 +1,7 @@
+export type AchievementName = 'SCRAPKING' | 'SCRAPQUEEN';
+
+export type Achievement = {
+  id: string;
+  name: AchievementName;
+  icon: string;
+};

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { AwsModule } from './aws/aws.module';
 import { EmotionModule } from './emotion/emotion.module';
 import { TagModule } from './tag/tag.module';
 import { PipesModule } from './common/pipes/pipes.module';
+import { AchievementModule } from './achievement/achievement.module';
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { PipesModule } from './common/pipes/pipes.module';
     AwsModule,
     EmotionModule,
     TagModule,
+    AchievementModule,
   ],
 })
 export class AppModule {}

--- a/test/e2e/achievement.e2e-spec.ts
+++ b/test/e2e/achievement.e2e-spec.ts
@@ -49,12 +49,14 @@ describe('Achievement (e2e)', () => {
         data: {
           icon: 'https://icon1.com',
           name: 'SCRAPKING',
+          description: '예뻐야 획득 가능함',
         },
       });
       const achievement2 = await prisma.achievement.create({
         data: {
           icon: 'https://icon2.com',
           name: 'SCRAPQUEEN',
+          description: '잘생겨야 획득 가능함',
         },
       });
       await prisma.achievementAcquisition.create({
@@ -96,12 +98,14 @@ describe('Achievement (e2e)', () => {
         data: {
           icon: 'https://icon1.com',
           name: 'SCRAPKING',
+          description: '잘생겨야 획득 가능함',
         },
       });
       const achievement2 = await prisma.achievement.create({
         data: {
           icon: 'https://icon2.com',
           name: 'SCRAPQUEEN',
+          description: '예뻐야 획득 가능함',
         },
       });
       await prisma.achievementAcquisition.create({

--- a/test/e2e/achievement.e2e-spec.ts
+++ b/test/e2e/achievement.e2e-spec.ts
@@ -87,7 +87,7 @@ describe('Achievement (e2e)', () => {
   });
 
   describe('GET /achievements/user - 특정 회원이 획득한 모든 업적 조회', async () => {
-    it('모든 업적 조회', async () => {
+    it('특정 회원이 획득한 모든 업적 조회', async () => {
       // given
       const { accessToken, name } = await login(app);
       const user = await prisma.user.findFirst({

--- a/test/e2e/achievement.e2e-spec.ts
+++ b/test/e2e/achievement.e2e-spec.ts
@@ -40,18 +40,27 @@ describe('Achievement (e2e)', () => {
   describe('GET /achievements - 모든 업적 조회', async () => {
     it('모든 업적 조회', async () => {
       // given
-      const { accessToken } = await login(app);
+      const { accessToken, name } = await login(app);
+      const user = await prisma.user.findFirst({
+        where: { name },
+      });
 
-      await prisma.achievement.create({
+      const achievement1 = await prisma.achievement.create({
         data: {
           icon: 'https://icon1.com',
           name: 'SCRAPKING',
         },
       });
-      await prisma.achievement.create({
+      const achievement2 = await prisma.achievement.create({
         data: {
           icon: 'https://icon2.com',
           name: 'SCRAPQUEEN',
+        },
+      });
+      await prisma.achievementAcquisition.create({
+        data: {
+          achievementId: achievement1.id,
+          userId: user!.id,
         },
       });
 
@@ -65,6 +74,8 @@ describe('Achievement (e2e)', () => {
       // then
       expect(status).toEqual(200);
       expect(body.length).toEqual(2);
+      expect(body[0].isAquired).toBe(true);
+      expect(body[1].isAquired).toBe(false);
       body.forEach((achievement) => {
         expect(achievement.id).toBeDefined();
         expect(achievement.name).toBeDefined();

--- a/test/e2e/achievement.e2e-spec.ts
+++ b/test/e2e/achievement.e2e-spec.ts
@@ -1,0 +1,74 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { describe } from 'node:test';
+import { AuthService } from 'src/auth/auth.service';
+import { AppModule } from 'src/app.module';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { AchievementsDto } from 'src/achievement/dto/response';
+import { login } from './helpers';
+
+describe('Achievement (e2e)', () => {
+  let app: INestApplication;
+  let authService: AuthService;
+  let prisma: PrismaService;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    prisma = moduleFixture.get<PrismaService>(PrismaService);
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    authService = moduleFixture.get<AuthService>(AuthService);
+    jest.spyOn(authService, 'getGoogleProfile').mockResolvedValue({
+      id: 'test-id',
+      email: 'test@test.com',
+      picture: 'https://picture.com',
+      verified_email: true,
+    });
+  });
+
+  afterEach(async () => {
+    await prisma.achievement.deleteMany();
+    await prisma.user.deleteMany();
+  });
+
+  describe('GET /achievements - 모든 업적 조회', async () => {
+    it('모든 업적 조회', async () => {
+      // given
+      const { accessToken } = await login(app);
+
+      await prisma.achievement.create({
+        data: {
+          icon: 'https://icon1.com',
+          name: 'SCRAPKING',
+        },
+      });
+      await prisma.achievement.create({
+        data: {
+          icon: 'https://icon2.com',
+          name: 'SCRAPQUEEN',
+        },
+      });
+
+      // when
+      const response = await request(app.getHttpServer())
+        .get('/achievements')
+        .set('Authorization', `Bearer ${accessToken}`);
+      const { status } = response;
+      const body: AchievementsDto[] = response.body;
+
+      // then
+      expect(status).toEqual(200);
+      expect(body.length).toEqual(2);
+      body.forEach((achievement) => {
+        expect(achievement.id).toBeDefined();
+        expect(achievement.name).toBeDefined();
+        expect(achievement.icon).toBeDefined();
+      });
+    });
+  });
+});

--- a/test/e2e/auth.e2e-spec.ts
+++ b/test/e2e/auth.e2e-spec.ts
@@ -2,7 +2,6 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { AppModule } from 'src/app.module';
-import { ValidationPipe } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { AuthService } from 'src/auth/auth.service';
 

--- a/test/e2e/helpers/index.ts
+++ b/test/e2e/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './login';

--- a/test/e2e/helpers/login.ts
+++ b/test/e2e/helpers/login.ts
@@ -1,0 +1,22 @@
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { SignupDto } from '../../../src/auth/dto/request';
+import { JwtDto } from '../../../src/auth/dto/response';
+
+export const login = async (app: INestApplication) => {
+  const dto: SignupDto = {
+    name: 'test',
+    provider: 'GOOGLE',
+    providerAccessToken: 'test-oauth-token',
+  };
+
+  const response = await request(app.getHttpServer())
+    .post('/auth/signup')
+    .send(dto);
+  const body: JwtDto = response.body;
+
+  return {
+    accessToken: body.accessToken,
+    name: dto.name,
+  };
+};

--- a/test/e2e/poem.e2e-spec.ts
+++ b/test/e2e/poem.e2e-spec.ts
@@ -2,9 +2,9 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { describe } from 'node:test';
-import { AuthService } from '../../src/auth/auth.service';
-import { AppModule } from '../../src/app.module';
-import { PrismaService } from '../../src/prisma/prisma.service';
+import { AuthService } from 'src/auth/auth.service';
+import { AppModule } from 'src/app.module';
+import { PrismaService } from 'src/prisma/prisma.service';
 import { LlmService } from 'src/poem/llm.service';
 import { login } from './helpers/login';
 

--- a/test/e2e/poem.e2e-spec.ts
+++ b/test/e2e/poem.e2e-spec.ts
@@ -4,10 +4,9 @@ import * as request from 'supertest';
 import { describe } from 'node:test';
 import { AuthService } from '../../src/auth/auth.service';
 import { AppModule } from '../../src/app.module';
-import { SignupDto } from '../../src/auth/dto/request';
-import { JwtDto } from '../../src/auth/dto/response';
 import { PrismaService } from '../../src/prisma/prisma.service';
 import { LlmService } from 'src/poem/llm.service';
+import { login } from './helpers/login';
 
 describe('Poem (e2e)', () => {
   let app: INestApplication;
@@ -223,21 +222,3 @@ describe('Poem (e2e)', () => {
     });
   });
 });
-
-const login = async (app: INestApplication) => {
-  const dto: SignupDto = {
-    name: 'test',
-    provider: 'GOOGLE',
-    providerAccessToken: 'test-oauth-token',
-  };
-
-  const response = await request(app.getHttpServer())
-    .post('/auth/signup')
-    .send(dto);
-  const body: JwtDto = response.body;
-
-  return {
-    accessToken: body.accessToken,
-    name: dto.name,
-  };
-};


### PR DESCRIPTION
## 🏷️ 연관 이슈
- #45 
## ✨ 작업 내용
- 모든 업적 조회 api 구현 (획득 여부 속성 있음)
- 특정 회원이 획득한 업적 조회 api 구현
- 테스트에 사용하는 login 함수 파일 분리
- Achievement 테이블에 description 컬럼 추가
## ETC
- 존재하는 회원인지 확인하는 코드는 나중에 회원 검색 구현되면 추가하려고 TODO 주석 추가해놨슴다.
