### PR TITLE
탈고 api에 글감 id 필드 추가

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,11 +48,14 @@ model Poem {
   status          String
   originalContent String?
   originalTitle   String?
-  createdAt       DateTime @default(now())
 
-  authorId String
-  author   User    @relation(fields: [authorId], references: [id])
-  scraps   Scrap[]
+  createdAt DateTime @default(now())
+
+  inspirationId String
+  inspiration   Inspiration @relation(fields: [inspirationId], references: [id], onDelete: NoAction)
+  authorId      String
+  author        User        @relation(fields: [authorId], references: [id])
+  scraps        Scrap[]
 }
 
 model Scrap {
@@ -90,4 +93,5 @@ model Inspiration {
   id          String          @id @default(uuid())
   type        InspirationType
   displayName String
+  Poem        Poem[]
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -93,5 +93,5 @@ model Inspiration {
   id          String          @id @default(uuid())
   type        InspirationType
   displayName String
-  Poem        Poem[]
+  poems       Poem[]
 }

--- a/src/poem/dto/request/create-poem.dto.ts
+++ b/src/poem/dto/request/create-poem.dto.ts
@@ -50,6 +50,10 @@ export class CreatePoemDto {
   @IsString()
   readonly originalTitle?: string;
 
+  @ApiProperty({ description: '글감의 ID' })
+  @IsString()
+  readonly inspirationId: string;
+
   @ApiProperty({
     type: 'string',
     format: 'binary',

--- a/src/poem/dto/response/new-poem.dto.ts
+++ b/src/poem/dto/response/new-poem.dto.ts
@@ -37,6 +37,9 @@ export class NewPoemDto {
   @ApiProperty()
   readonly authorId: string;
 
+  @ApiProperty({ description: '글감 ID' })
+  readonly inspirationId: string;
+
   @ApiProperty({ description: '녹음 파일 URL', required: false })
   readonly audioUrl?: string;
 }

--- a/src/poem/poem.prisma.repository.ts
+++ b/src/poem/poem.prisma.repository.ts
@@ -7,7 +7,7 @@ import { PrismaService } from '../prisma/prisma.service';
 export class PoemPrismaRepository implements PoemRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  async create(userId: string, data: Prisma.PoemCreateWithoutAuthorInput) {
+  async create(userId: string, data: CreateInput) {
     return this.prisma.poem.create({
       data: {
         ...data,
@@ -32,3 +32,18 @@ export class PoemPrismaRepository implements PoemRepository {
     });
   }
 }
+
+export type CreateInput = {
+  title: string;
+  content: string;
+  themes: string[];
+  interactions: string[];
+  textAlign: string;
+  textSize: number;
+  textFont: string;
+  isRecorded: boolean;
+  originalContent?: string | null;
+  originalTitle?: string | null;
+  inspirationId: string;
+  status: string;
+};

--- a/src/poem/poem.repository.ts
+++ b/src/poem/poem.repository.ts
@@ -14,6 +14,7 @@ export type CreateInput = {
   isRecorded: boolean;
   originalContent?: string | null;
   originalTitle?: string | null;
+  inspirationId: string;
   status: string;
 };
 
@@ -29,6 +30,7 @@ export type Poem = {
   isRecorded: boolean;
   status: string;
   createdAt: Date;
+  inspirationId: string;
   authorId: string;
 };
 

--- a/src/poem/poem.service.ts
+++ b/src/poem/poem.service.ts
@@ -32,6 +32,7 @@ export class PoemService {
       isRecorded: createInput.audioFile ? true : false,
       originalContent: createInput.originalContent ?? null,
       originalTitle: createInput.originalTitle ?? null,
+      inspirationId: createInput.inspirationId,
       status: '교정중',
     };
 
@@ -85,6 +86,7 @@ export type CreateInput = {
   textFont: string;
   originalContent?: string;
   originalTitle?: string;
+  inspirationId: string;
   audioFile?: Express.Multer.File;
 };
 

--- a/test/e2e/poem.e2e-spec.ts
+++ b/test/e2e/poem.e2e-spec.ts
@@ -427,7 +427,6 @@ describe('Poem (e2e)', () => {
         .field('inspirationId', createPoemDto.inspirationId);
 
       // then
-      console.log(body);
       expect(status).toEqual(201);
       expect(body).toEqual({
         id: expect.any(String),


### PR DESCRIPTION
## 🏷️ 연관 이슈

- close #39 

## ✨ 작업 내용
- 기존 탈고 api에 글감 id 필드 추가
- 기존 Scrap E2E 테스트에서 poem에 대한 테스트용 데이터를 삽입하는 부분을 새로운 스키마에 맞게 수정
- POST /poems - 탈고하기 E2E 테스트
  - 시를 탈고하면 201 응답과 함께 newPoemDto를 반환한다
  - 녹음 파일이 있는 경우, 녹음 파일의 URL도 함께 반환한다
  - AwsModule은 모킹하지 않고 실제 파일로 테스트함.
