### PR TITLE
관리자용 - 교정중인 시 목록조회, 교정중인 시 내용 조회, 출판 기능

### DIFF
--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -5,6 +5,7 @@ import {
   UploadedFile,
   Body,
   Get,
+  Param,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -15,7 +16,7 @@ import {
 } from '@nestjs/swagger';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { UploadInspirationDto } from './dto/request';
-import { ProofreadingPoemDto } from './dto/response';
+import { ProofreadingPoemDto, ProofreadingPoemDetailDto } from './dto/response';
 import { InspirationService } from 'src/inspiration/inspiration.service';
 import { PoemService } from 'src/poem/poem.service';
 
@@ -53,5 +54,12 @@ export class AdminController {
   @Get('poems/proofreading')
   async findAllProofreading() {
     return await this.poemService.getProofreadingList();
+  }
+
+  @ApiOperation({ summary: '교정중인 시 조회' })
+  @ApiResponse({ status: 200, type: ProofreadingPoemDetailDto })
+  @Get('poems/proofreading/:id')
+  async findOneProofreading(@Param('id') id: string) {
+    return await this.poemService.getOneProofreading(id);
   }
 }

--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -4,6 +4,7 @@ import {
   UseInterceptors,
   UploadedFile,
   Body,
+  Get,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -14,12 +15,17 @@ import {
 } from '@nestjs/swagger';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { UploadInspirationDto } from './dto/request';
+import { ProofreadingPoemDto } from './dto/response';
 import { InspirationService } from 'src/inspiration/inspiration.service';
+import { PoemService } from 'src/poem/poem.service';
 
 @ApiTags('admin')
 @Controller('admin')
 export class AdminController {
-  constructor(private readonly inspirationService: InspirationService) {}
+  constructor(
+    private readonly inspirationService: InspirationService,
+    private readonly poemService: PoemService,
+  ) {}
 
   @ApiOperation({ summary: '글감 업로드' })
   @ApiConsumes('multipart/form-data')
@@ -40,5 +46,12 @@ export class AdminController {
     } else if (body.type === 'VIDEO') {
       await this.inspirationService.createVideo(file!);
     }
+  }
+
+  @ApiOperation({ summary: '교정중인 시 목록 조회 (탈고만 된거)' })
+  @ApiResponse({ status: 200, type: [ProofreadingPoemDto] })
+  @Get('poems/proofreading')
+  async findAllProofreading() {
+    return await this.poemService.getProofreadingList();
   }
 }

--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -6,6 +6,7 @@ import {
   Body,
   Get,
   Param,
+  Patch,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -61,5 +62,13 @@ export class AdminController {
   @Get('poems/proofreading/:id')
   async findOneProofreading(@Param('id') id: string) {
     return await this.poemService.getOneProofreading(id);
+  }
+
+  @ApiOperation({ summary: '출판' })
+  @ApiResponse({ status: 200, description: '출판 성공' })
+  @Patch('poems/proofreading/:id/publish')
+  async publish(@Param('id') id: string) {
+    await this.poemService.publish(id);
+    return;
   }
 }

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { AdminController } from './admin.controller';
 import { InspirationModule } from 'src/inspiration/inspiration.module';
+import { PoemModule } from 'src/poem/poem.module';
 
 @Module({
-  imports: [InspirationModule],
+  imports: [InspirationModule, PoemModule],
   controllers: [AdminController],
 })
 export class AdminModule {}

--- a/src/admin/dto/request/upload-inspiration.dto.ts
+++ b/src/admin/dto/request/upload-inspiration.dto.ts
@@ -8,7 +8,7 @@ export class UploadInspirationDto {
   @ApiProperty({ enum: typeList, description: 'TITLE, WORD, AUDIO, VIDEO' })
   @Transform(({ value }) => value.toUpperCase())
   @IsEnum(typeList)
-  type: 'TITLE' | 'WORD' | 'AUDIO' | 'VIDEO';
+  readonly type: 'TITLE' | 'WORD' | 'AUDIO' | 'VIDEO';
 
   @ApiProperty({
     required: false,
@@ -17,12 +17,12 @@ export class UploadInspirationDto {
   })
   @IsOptional()
   @IsString()
-  text?: string | null;
+  readonly text?: string | null;
 
   @ApiProperty({
     required: false,
     description: '타입이 AUDIO, VIDEO일 경우에만 필수',
     type: 'file',
   })
-  file?: Express.Multer.File | null;
+  readonly file?: Express.Multer.File | null;
 }

--- a/src/admin/dto/response/index.ts
+++ b/src/admin/dto/response/index.ts
@@ -1,1 +1,2 @@
 export * from './proofreading-poem-list.dto';
+export * from './proofreading-poem.dto';

--- a/src/admin/dto/response/index.ts
+++ b/src/admin/dto/response/index.ts
@@ -1,0 +1,1 @@
+export * from './proofreading-poem-list.dto';

--- a/src/admin/dto/response/proofreading-poem-list.dto.ts
+++ b/src/admin/dto/response/proofreading-poem-list.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ProofreadingPoemDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  title: string;
+}

--- a/src/admin/dto/response/proofreading-poem-list.dto.ts
+++ b/src/admin/dto/response/proofreading-poem-list.dto.ts
@@ -2,8 +2,8 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class ProofreadingPoemDto {
   @ApiProperty()
-  id: string;
+  readonly id: string;
 
   @ApiProperty()
-  title: string;
+  readonly title: string;
 }

--- a/src/admin/dto/response/proofreading-poem.dto.ts
+++ b/src/admin/dto/response/proofreading-poem.dto.ts
@@ -3,79 +3,79 @@ import { themes, interactions } from 'src/constants/tags';
 
 export class BaseInspirationDto {
   @ApiProperty()
-  id: string;
+  readonly id: string;
 
   @ApiProperty()
-  displayName: string;
+  readonly displayName: string;
 
   @ApiProperty()
-  type: string;
+  readonly type: string;
 }
 
 export class TextInspirationDto extends BaseInspirationDto {
   @ApiProperty({ enum: ['TITLE', 'WORD'] })
-  type: 'TITLE' | 'WORD';
+  readonly type: 'TITLE' | 'WORD';
 }
 
 export class AudioInspirationDto extends BaseInspirationDto {
   @ApiProperty()
-  type: 'AUDIO';
+  readonly type: 'AUDIO';
 
   @ApiProperty()
-  audioUrl: string;
+  readonly audioUrl: string;
 }
 
 export class VideoInspirationDto extends BaseInspirationDto {
   @ApiProperty()
-  type: 'VIDEO';
+  readonly type: 'VIDEO';
 
   @ApiProperty()
-  videoUrl: string;
+  readonly videoUrl: string;
 }
 
 @ApiExtraModels(TextInspirationDto, AudioInspirationDto, VideoInspirationDto)
 export class ProofreadingPoemDetailDto {
   @ApiProperty()
-  id: string;
+  readonly id: string;
 
   @ApiProperty()
-  title: string;
+  readonly title: string;
 
   @ApiProperty()
-  content: string;
+  readonly content: string;
 
   @ApiProperty()
-  textAlign: string;
+  readonly textAlign: string;
 
   @ApiProperty()
-  textSize: number;
+  readonly textSize: number;
 
   @ApiProperty()
-  textFont: string;
+  readonly textFont: string;
 
   @ApiProperty({ isArray: true, enum: themes })
-  themes: string[];
+  readonly themes: string[];
 
   @ApiProperty({ isArray: true, enum: interactions })
-  interactions: string[];
+  readonly interactions: string[];
 
   @ApiProperty()
-  isRecorded: boolean;
+  readonly isRecorded: boolean;
 
   @ApiProperty({ required: false })
-  audioUrl?: string;
+  readonly audioUrl?: string;
 
   @ApiProperty()
-  status: '교정중';
+  readonly status: '교정중';
 
   @ApiProperty({ type: 'string', nullable: true })
-  originalContent: string | null;
+  readonly originalContent: string | null;
 
   @ApiProperty({ type: 'string', nullable: true })
-  originalTitle: string | null;
+  readonly originalTitle: string | null;
 
   @ApiProperty({ description: 'ISO 8601' })
-  createdAt: Date;
+  readonly createdAt: Date;
 
   @ApiProperty({
     oneOf: [
@@ -85,8 +85,11 @@ export class ProofreadingPoemDetailDto {
     ],
     discriminator: { propertyName: 'type' },
   })
-  inspiration: TextInspirationDto | AudioInspirationDto | VideoInspirationDto;
+  readonly inspiration:
+    | TextInspirationDto
+    | AudioInspirationDto
+    | VideoInspirationDto;
 
   @ApiProperty()
-  authorId: string;
+  readonly authorId: string;
 }

--- a/src/admin/dto/response/proofreading-poem.dto.ts
+++ b/src/admin/dto/response/proofreading-poem.dto.ts
@@ -1,0 +1,92 @@
+import { ApiProperty, getSchemaPath, ApiExtraModels } from '@nestjs/swagger';
+import { themes, interactions } from 'src/constants/tags';
+
+export class BaseInspirationDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  displayName: string;
+
+  @ApiProperty()
+  type: string;
+}
+
+export class TextInspirationDto extends BaseInspirationDto {
+  @ApiProperty({ enum: ['TITLE', 'WORD'] })
+  type: 'TITLE' | 'WORD';
+}
+
+export class AudioInspirationDto extends BaseInspirationDto {
+  @ApiProperty()
+  type: 'AUDIO';
+
+  @ApiProperty()
+  audioUrl: string;
+}
+
+export class VideoInspirationDto extends BaseInspirationDto {
+  @ApiProperty()
+  type: 'VIDEO';
+
+  @ApiProperty()
+  videoUrl: string;
+}
+
+@ApiExtraModels(TextInspirationDto, AudioInspirationDto, VideoInspirationDto)
+export class ProofreadingPoemDetailDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  title: string;
+
+  @ApiProperty()
+  content: string;
+
+  @ApiProperty()
+  textAlign: string;
+
+  @ApiProperty()
+  textSize: number;
+
+  @ApiProperty()
+  textFont: string;
+
+  @ApiProperty({ isArray: true, enum: themes })
+  themes: string[];
+
+  @ApiProperty({ isArray: true, enum: interactions })
+  interactions: string[];
+
+  @ApiProperty()
+  isRecorded: boolean;
+
+  @ApiProperty({ required: false })
+  audioUrl?: string;
+
+  @ApiProperty()
+  status: '교정중';
+
+  @ApiProperty({ type: 'string', nullable: true })
+  originalContent: string | null;
+
+  @ApiProperty({ type: 'string', nullable: true })
+  originalTitle: string | null;
+
+  @ApiProperty({ description: 'ISO 8601' })
+  createdAt: Date;
+
+  @ApiProperty({
+    oneOf: [
+      { $ref: getSchemaPath(TextInspirationDto) },
+      { $ref: getSchemaPath(AudioInspirationDto) },
+      { $ref: getSchemaPath(VideoInspirationDto) },
+    ],
+    discriminator: { propertyName: 'type' },
+  })
+  inspiration: TextInspirationDto | AudioInspirationDto | VideoInspirationDto;
+
+  @ApiProperty()
+  authorId: string;
+}

--- a/src/constants/inspiration-type.ts
+++ b/src/constants/inspiration-type.ts
@@ -1,0 +1,1 @@
+export const inspirationTypes = ['TITLE', 'WORD', 'AUDIO', 'VIDEO'] as const;

--- a/src/poem/poem.module.ts
+++ b/src/poem/poem.module.ts
@@ -23,5 +23,6 @@ import { ScrapPrismaRepository } from './scrap.prisma.repository';
       useClass: ScrapPrismaRepository,
     },
   ],
+  exports: [PoemService],
 })
 export class PoemModule {}

--- a/src/poem/poem.prisma.repository.ts
+++ b/src/poem/poem.prisma.repository.ts
@@ -57,6 +57,18 @@ export class PoemPrismaRepository implements PoemRepository {
       },
     });
   }
+
+  async updateStatus(id: string, status: string) {
+    await this.prisma.poem.update({
+      where: {
+        id,
+      },
+      data: {
+        status,
+      },
+    });
+    return;
+  }
 }
 
 export type CreateInput = {

--- a/src/poem/poem.prisma.repository.ts
+++ b/src/poem/poem.prisma.repository.ts
@@ -43,6 +43,20 @@ export class PoemPrismaRepository implements PoemRepository {
       },
     });
   }
+
+  async findOneProofreading(id: string) {
+    return this.prisma.poem.findUnique({
+      where: {
+        id,
+      },
+      include: {
+        inspiration: true,
+      },
+      omit: {
+        inspirationId: true,
+      },
+    });
+  }
 }
 
 export type CreateInput = {

--- a/src/poem/poem.prisma.repository.ts
+++ b/src/poem/poem.prisma.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
-import { PoemRepository } from './poem.repository';
+import { Poem, PoemRepository } from './poem.repository';
 import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
@@ -28,6 +28,18 @@ export class PoemPrismaRepository implements PoemRepository {
           gte: new Date(new Date().setHours(0, 0, 0, 0)),
           lt: new Date(new Date().setHours(23, 59, 59, 999)),
         },
+      },
+    });
+  }
+
+  async findAllProofreading() {
+    return this.prisma.poem.findMany({
+      where: {
+        status: '교정중',
+      },
+      select: {
+        id: true,
+        title: true,
       },
     });
   }

--- a/src/poem/poem.repository.ts
+++ b/src/poem/poem.repository.ts
@@ -3,6 +3,7 @@ export interface PoemRepository {
   countUserDaily(userId: string): Promise<number>;
   findAllProofreading(): Promise<ProofreadingPoemList>;
   findOneProofreading(id: string): Promise<PoemWithOriginalContent | null>;
+  updateStatus(id: string, status: string): Promise<void>;
 }
 
 export type CreateInput = {

--- a/src/poem/poem.repository.ts
+++ b/src/poem/poem.repository.ts
@@ -1,6 +1,7 @@
 export interface PoemRepository {
   create(userId: string, data: CreateInput): Promise<Poem>;
   countUserDaily(userId: string): Promise<number>;
+  findAllProofreading(): Promise<ProofreadingPoemList>;
 }
 
 export type CreateInput = {
@@ -33,5 +34,10 @@ export type Poem = {
   inspirationId: string;
   authorId: string;
 };
+
+export type ProofreadingPoemList = {
+  id: string;
+  title: string;
+}[];
 
 export const PoemRepository = Symbol('PoemRepository');

--- a/src/poem/poem.repository.ts
+++ b/src/poem/poem.repository.ts
@@ -2,6 +2,7 @@ export interface PoemRepository {
   create(userId: string, data: CreateInput): Promise<Poem>;
   countUserDaily(userId: string): Promise<number>;
   findAllProofreading(): Promise<ProofreadingPoemList>;
+  findOneProofreading(id: string): Promise<PoemWithOriginalContent | null>;
 }
 
 export type CreateInput = {
@@ -39,5 +40,18 @@ export type ProofreadingPoemList = {
   id: string;
   title: string;
 }[];
+
+export type PoemWithOriginalContent = Omit<
+  Poem & {
+    originalTitle: string | null;
+    originalContent: string | null;
+    inspiration: {
+      id: string;
+      displayName: string;
+      type: 'TITLE' | 'WORD' | 'AUDIO' | 'VIDEO';
+    };
+  },
+  'inspirationId'
+>;
 
 export const PoemRepository = Symbol('PoemRepository');

--- a/src/poem/poem.service.ts
+++ b/src/poem/poem.service.ts
@@ -114,6 +114,10 @@ export class PoemService {
       inspiration: inspirationData,
     };
   }
+
+  async publish(id: string) {
+    await this.poemRepository.updateStatus(id, '출판');
+  }
 }
 
 export type CreateInput = {

--- a/src/poem/poem.service.ts
+++ b/src/poem/poem.service.ts
@@ -78,6 +78,42 @@ export class PoemService {
   async getProofreadingList() {
     return await this.poemRepository.findAllProofreading();
   }
+
+  async getOneProofreading(id: string) {
+    const poem = await this.poemRepository.findOneProofreading(id);
+    if (!poem) {
+      throw new Error('해당 시가 존재하지 않습니다.');
+    }
+    let inspirationData;
+    if (poem.inspiration.type === 'AUDIO') {
+      inspirationData = {
+        ...poem.inspiration,
+        audioUrl:
+          this.awsService.getAudioInspirationUrl() +
+          poem.inspiration.displayName,
+      };
+    } else if (poem.inspiration.type === 'VIDEO') {
+      inspirationData = {
+        ...poem.inspiration,
+        videoUrl:
+          this.awsService.getVideoInspirationUrl() +
+          poem.inspiration.displayName,
+      };
+    } else {
+      inspirationData = poem.inspiration;
+    }
+    if (poem.isRecorded) {
+      return {
+        ...poem,
+        audioUrl: this.awsService.getPoemAudioUrl() + poem.id,
+        inspiration: inspirationData,
+      };
+    }
+    return {
+      ...poem,
+      inspiration: inspirationData,
+    };
+  }
 }
 
 export type CreateInput = {

--- a/src/poem/poem.service.ts
+++ b/src/poem/poem.service.ts
@@ -74,6 +74,10 @@ export class PoemService {
       return false;
     }
   }
+
+  async getProofreadingList() {
+    return await this.poemRepository.findAllProofreading();
+  }
 }
 
 export type CreateInput = {

--- a/test/e2e/admin.e2e-spec.ts
+++ b/test/e2e/admin.e2e-spec.ts
@@ -286,4 +286,47 @@ describe('Admin (e2e)', () => {
       expect(body.inspiration.audioUrl).toBeDefined();
     });
   });
+
+  describe('PATCH /admin/poems/proofreading/:id/publish - 출판', () => {
+    it('시를 출판한다', async () => {
+      // given
+      const { accessToken, name } = await login(app);
+      const user = await prisma.user.findFirst({
+        where: { name },
+      });
+      const inspiration = await prisma.inspiration.create({
+        data: {
+          type: 'TITLE',
+          displayName: 'test-title',
+        },
+      });
+      const poem = await prisma.poem.create({
+        data: {
+          title: 'test-title',
+          content: 'test-content',
+          themes: ['test-theme'],
+          interactions: ['test-interaction'],
+          textAlign: 'center',
+          textSize: 16,
+          textFont: 'test-font',
+          isRecorded: false,
+          inspirationId: inspiration.id,
+          status: '교정중',
+          authorId: user!.id,
+        },
+      });
+
+      // when
+      const { status } = await request(app.getHttpServer()).patch(
+        `/admin/poems/proofreading/${poem.id}/publish`,
+      );
+
+      // then
+      expect(status).toBe(200);
+      const publishedPoem = await prisma.poem.findUnique({
+        where: { id: poem.id },
+      });
+      expect(publishedPoem?.status).toBe('출판');
+    });
+  });
 });

--- a/test/e2e/admin.e2e-spec.ts
+++ b/test/e2e/admin.e2e-spec.ts
@@ -6,10 +6,13 @@ import { PrismaService } from 'src/prisma/prisma.service';
 import * as fs from 'fs';
 import * as path from 'path';
 import { S3Client, DeleteObjectCommand } from '@aws-sdk/client-s3';
+import { login } from './helpers';
+import { AuthService } from 'src/auth/auth.service';
 
 describe('Admin (e2e)', () => {
   let app: INestApplication;
   let prisma: PrismaService;
+  let authService: AuthService;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -17,13 +20,23 @@ describe('Admin (e2e)', () => {
     }).compile();
 
     prisma = moduleFixture.get<PrismaService>(PrismaService);
+    authService = moduleFixture.get<AuthService>(AuthService);
 
     app = moduleFixture.createNestApplication();
     await app.init();
+
+    jest.spyOn(authService, 'getGoogleProfile').mockResolvedValue({
+      id: 'test-id',
+      email: 'test@test.com',
+      picture: 'https://picture.com',
+      verified_email: true,
+    });
   });
 
   afterEach(async () => {
+    await prisma.poem.deleteMany();
     await prisma.inspiration.deleteMany();
+    await prisma.user.deleteMany();
   });
 
   describe('POST /admin/inspirations - 글감 업로드', () => {
@@ -133,6 +146,64 @@ describe('Admin (e2e)', () => {
           Key: 'inspirations/videos/test.mp4',
         }),
       );
+    });
+  });
+
+  describe('GET /admin/poems/proofreading - 교정중인 시 목록 조회', () => {
+    it('교정중인 시 목록을 조회한다', async () => {
+      // given
+      const { accessToken, name } = await login(app);
+      const user = await prisma.user.findFirst({
+        where: { name },
+      });
+      const inspiration = await prisma.inspiration.create({
+        data: {
+          type: 'TITLE',
+          displayName: 'test-title',
+        },
+      });
+      const testData = [
+        {
+          title: 'test-title',
+          content: 'test-content',
+          themes: ['test-theme'],
+          interactions: ['test-interaction'],
+          textAlign: 'center',
+          textSize: 16,
+          textFont: 'test-font',
+          isRecorded: false,
+          inspirationId: inspiration.id,
+          status: '교정중',
+          authorId: user!.id,
+        },
+        {
+          title: 'test-title2',
+          content: 'test-content2',
+          themes: ['test-theme2'],
+          interactions: ['test-interaction2'],
+          textAlign: 'center',
+          textSize: 16,
+          textFont: 'test-font',
+          isRecorded: false,
+          inspirationId: inspiration.id,
+          status: '교정중',
+          authorId: user!.id,
+        },
+      ];
+      await prisma.poem.createMany({
+        data: testData,
+      });
+
+      // when
+      const { status, body } = await request(app.getHttpServer()).get(
+        '/admin/poems/proofreading',
+      );
+
+      // then
+      expect(status).toBe(200);
+      expect(body).toHaveLength(2);
+      expect(body[0].title).toBe(testData[0].title);
+      expect(body[1].title).toBe(testData[1].title);
     });
   });
 });

--- a/test/e2e/admin.e2e-spec.ts
+++ b/test/e2e/admin.e2e-spec.ts
@@ -206,4 +206,84 @@ describe('Admin (e2e)', () => {
       expect(body[1].title).toBe(testData[1].title);
     });
   });
+
+  describe('GET /admin/poems/proofreading/:id - 교정중인 시 조회', () => {
+    it('시에 낭독 데이터가 있으면 audioUrl을 포함해서 반환한다.', async () => {
+      // given
+      const { accessToken, name } = await login(app);
+      const user = await prisma.user.findFirst({
+        where: { name },
+      });
+      const inspiration = await prisma.inspiration.create({
+        data: {
+          type: 'TITLE',
+          displayName: 'test-title',
+        },
+      });
+      const poem = await prisma.poem.create({
+        data: {
+          title: 'test-title',
+          content: 'test-content',
+          themes: ['test-theme'],
+          interactions: ['test-interaction'],
+          textAlign: 'center',
+          textSize: 16,
+          textFont: 'test-font',
+          isRecorded: true,
+          inspirationId: inspiration.id,
+          status: '교정중',
+          authorId: user!.id,
+        },
+      });
+
+      // when
+      const { status, body } = await request(app.getHttpServer()).get(
+        `/admin/poems/proofreading/${poem.id}`,
+      );
+
+      // then
+      expect(status).toBe(200);
+      expect(body.title).toBe(poem.title);
+      expect(body.audioUrl).toBeDefined();
+    });
+
+    it('글감이 오디오일땐 audioUrl을 inspiration에 포함해서 반환한다', async () => {
+      // given
+      const { accessToken, name } = await login(app);
+      const user = await prisma.user.findFirst({
+        where: { name },
+      });
+      const inspiration = await prisma.inspiration.create({
+        data: {
+          type: 'AUDIO',
+          displayName: 'test.mp3',
+        },
+      });
+      const poem = await prisma.poem.create({
+        data: {
+          title: 'test-title',
+          content: 'test-content',
+          themes: ['test-theme'],
+          interactions: ['test-interaction'],
+          textAlign: 'center',
+          textSize: 16,
+          textFont: 'test-font',
+          isRecorded: false,
+          inspirationId: inspiration.id,
+          status: '교정중',
+          authorId: user!.id,
+        },
+      });
+
+      // when
+      const { status, body } = await request(app.getHttpServer()).get(
+        `/admin/poems/proofreading/${poem.id}`,
+      );
+
+      // then
+      expect(status).toBe(200);
+      expect(body.title).toBe(poem.title);
+      expect(body.inspiration.audioUrl).toBeDefined();
+    });
+  });
 });


### PR DESCRIPTION
## 🏷️ 연관 이슈

- close #42 

## ✨ 작업 내용
- 교정중인 전체 시 리스트를 반환하는 GET /admin/poems/proofreading
- 교정중인 시 중 하나의 id를 받아서 내용을 반환하는 GET /admin/poems/proofreading/:id
- 시의 id를 받아서 status를 '출판' 으로 변경하는 PATCH /admin/poems/proofreading/:id/publish
- 및 위의 기능들 전부 E2E Test 구현

## 고려사항
- 반려기능은 없음. 출판만 하는걸로. 반려된 시는 다 삭제되는건지를 몰라서
- poem.Repository.updateStatus(id, status) 함수