### PR TITLE
로그인 및 회원가입 api에서 response에 필명 필드 추가

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -26,7 +26,7 @@ export class AuthService {
         throw new Error('user not found');
       }
       const jwtAccessToken = await this.createAccessToken(user.id);
-      return { accessToken: jwtAccessToken };
+      return { accessToken: jwtAccessToken, name: user.name };
     }
   }
 
@@ -47,7 +47,7 @@ export class AuthService {
         name,
       });
       const jwtAccessToken = await this.createAccessToken(newUser.id);
-      return { accessToken: jwtAccessToken };
+      return { accessToken: jwtAccessToken, name: newUser.name };
     }
   }
 

--- a/src/auth/dto/response/jwt.dto.ts
+++ b/src/auth/dto/response/jwt.dto.ts
@@ -3,4 +3,7 @@ import { ApiProperty } from '@nestjs/swagger';
 export class JwtDto {
   @ApiProperty()
   readonly accessToken: string;
+
+  @ApiProperty()
+  readonly name: string;
 }

--- a/test/e2e/auth.e2e-spec.ts
+++ b/test/e2e/auth.e2e-spec.ts
@@ -118,6 +118,7 @@ describe('Auth (e2e)', () => {
       // then
       expect(response.status).toBe(201);
       expect(response.body.accessToken).toBeDefined();
+      expect(response.body.name).toBe(signupDto.name);
 
       const user = await prisma.user.findFirst({
         where: {
@@ -168,6 +169,7 @@ describe('Auth (e2e)', () => {
       // then
       expect(response.status).toBe(200);
       expect(response.body.accessToken).toBeDefined();
+      expect(response.body.name).toBe(user.name);
     });
 
     it('provider에 GOOGLE과 APPLE이 아닌 값이 들어오면 400을 반환한다', async () => {


### PR DESCRIPTION
## 🏷️ 연관 이슈

- close #55 

## ✨ 작업 내용
- 로그인 및 회원가입 api의 response에 필명 필드 추가
- E2E Test 추가
