### PR TITLE
업적 관련 api 문서 수정

### DIFF
--- a/src/achievement/achievement.controller.ts
+++ b/src/achievement/achievement.controller.ts
@@ -25,16 +25,19 @@ export class AchievementController {
   constructor(private readonly achievementService: AchievementService) {}
 
   @ApiOperation({
-    summary: '모든 업적 조회',
+    summary: '자신이 획득한 업적 조회',
+    description:
+      '모든 업적을 조회하고 로그인 한 회원의 획득 유무를 isAquired로 표시합니다.',
   })
   @ApiResponse({ status: 200, type: [AchievementsDto] })
-  @Get()
+  @Get('my')
   async getAll(@CurrentUser() userId: string) {
     return await this.achievementService.getAll(userId);
   }
 
   @ApiOperation({
     summary: '특정 회원이 획득한 모든 업적 조회',
+    deprecated: true,
   })
   @ApiResponse({ status: 200, type: [AchievementsDto] })
   @Get('user')

--- a/test/e2e/achievement.e2e-spec.ts
+++ b/test/e2e/achievement.e2e-spec.ts
@@ -37,8 +37,8 @@ describe('Achievement (e2e)', () => {
     await prisma.user.deleteMany();
   });
 
-  describe('GET /achievements - 모든 업적 조회', async () => {
-    it('모든 업적 조회', async () => {
+  describe('GET /achievements - 자신이 획득한 업적 조회', async () => {
+    it('자신이 획득한 업적 조회', async () => {
       // given
       const { accessToken, name } = await login(app);
       const user = await prisma.user.findFirst({
@@ -68,7 +68,7 @@ describe('Achievement (e2e)', () => {
 
       // when
       const response = await request(app.getHttpServer())
-        .get('/achievements')
+        .get('/achievements/my')
         .set('Authorization', `Bearer ${accessToken}`);
       const { status } = response;
       const body: AchievementsDto[] = response.body;


### PR DESCRIPTION
## 🏷️ 연관 이슈
- #57 
## ✨ 작업 내용
- 자신이 획득한 업적 조회 api의 end point 변경 (/achievement -> /achievement/my)
- description 추가
- 현재 사용하지 않는 api deprecated 설정