### PR TITLE
GET /poems?emotion&index - 감정 알고리즘에 맞춰 시를 3개씩 반환하는 api

### DIFF
--- a/src/constants/emotions.ts
+++ b/src/constants/emotions.ts
@@ -23,4 +23,4 @@ export const emotions = [
     emotion: '분노',
     description: ['격노', '좌절', '경멸'],
   },
-];
+] as const;

--- a/src/constants/tags.ts
+++ b/src/constants/tags.ts
@@ -1,3 +1,45 @@
+import { emotions } from './emotions';
+export type Theme =
+  | '로맨틱'
+  | '우정'
+  | '가족'
+  | '성장'
+  | '희망'
+  | '자연'
+  | '외로움'
+  | '상실'
+  | '죽음'
+  | '그리움'
+  | '영적'
+  | '성공'
+  | '평화'
+  | '즐거움'
+  | '기쁨'
+  | '갈등'
+  | '화해'
+  | '불확실성'
+  | '추악함'
+  | '좌절'
+  | '불의'
+  | '사랑'
+  | '연민';
+
+export type Interaction =
+  | '위로'
+  | '카타르시스'
+  | '감사'
+  | '환희'
+  | '성찰'
+  | '격려'
+  | '노스텔지아'
+  | '자아비판'
+  | '연대감'
+  | '감성적'
+  | '이성적'
+  | '의문'
+  | '상상력'
+  | '축하';
+
 export const themes = [
   '로맨틱',
   '우정',
@@ -22,7 +64,7 @@ export const themes = [
   '불의',
   '사랑',
   '연민',
-] as const;
+] as Theme[];
 
 export const interactions = [
   '위로',
@@ -39,7 +81,7 @@ export const interactions = [
   '의문',
   '상상력',
   '축하',
-] as const;
+] as Interaction[];
 
 export const firstTags = [
   {
@@ -72,7 +114,11 @@ export const firstTags = [
     themes: ['갈등', '추악함', '불의', '상실'],
     interactions: ['자아비판', '이성적', '의문'],
   },
-] as const;
+] as {
+  emotion: (typeof emotions)[number]['emotion'];
+  themes: Theme[];
+  interactions: Interaction[];
+}[];
 
 export const secondTags = [
   {
@@ -105,4 +151,8 @@ export const secondTags = [
     themes: ['자연', '평화', '화해', '즐거움', '기쁨', '사랑'],
     interactions: ['위로', '카타르시스', '감사', '환희', '감성적'],
   },
-] as const;
+] as {
+  emotion: (typeof emotions)[number]['emotion'];
+  themes: Theme[];
+  interactions: Interaction[];
+}[];

--- a/src/constants/tags.ts
+++ b/src/constants/tags.ts
@@ -22,7 +22,7 @@ export const themes = [
   '불의',
   '사랑',
   '연민',
-];
+] as const;
 
 export const interactions = [
   '위로',
@@ -39,4 +39,70 @@ export const interactions = [
   '의문',
   '상상력',
   '축하',
-];
+] as const;
+
+export const firstTags = [
+  {
+    emotion: '슬픔',
+    themes: ['외로움', '상실', '연민', '죽음', '그리움', '좌절'],
+    interactions: ['노스텔지아', '감성적'],
+  },
+  {
+    emotion: '기쁨',
+    themes: ['로맨틱', '성공', '우정', '가족', '즐거움', '기쁨', '화해'],
+    interactions: ['감사', '환희', '감성적', '축하'],
+  },
+  {
+    emotion: '두려움',
+    themes: ['자연', '외로움', '성장', '갈등', '죽음', '불확실성'],
+    interactions: ['자아비판', '의문'],
+  },
+  {
+    emotion: '신뢰',
+    themes: ['우정', '평화', '가족', '기쁨', '영적', '화해'],
+    interactions: ['격려', '감사', '연대감'],
+  },
+  {
+    emotion: '기대',
+    themes: ['로맨틱', '성장', '희망', '영적', '자연', '성공'],
+    interactions: ['성찰', '격려', '상상력'],
+  },
+  {
+    emotion: '분노',
+    themes: ['갈등', '추악함', '불의', '상실'],
+    interactions: ['자아비판', '이성적', '의문'],
+  },
+] as const;
+
+export const secondTags = [
+  {
+    emotion: '슬픔',
+    themes: ['가족', '희망', '성공', '화해', '사랑'],
+    interactions: ['위로', '연대감', '환희'],
+  },
+  {
+    emotion: '기쁨',
+    themes: [],
+    interactions: ['성찰', '이성적'],
+  },
+  {
+    emotion: '두려움',
+    themes: ['희망', '영적', '성장', '평화', '기쁨'],
+    interactions: ['연대감', '카타르시스', '상상력'],
+  },
+  {
+    emotion: '신뢰',
+    themes: [],
+    interactions: ['성찰', '이성적', '의문'],
+  },
+  {
+    emotion: '기대',
+    themes: [],
+    interactions: ['노스텔지아', '자아비판', '이성적', '축하'],
+  },
+  {
+    emotion: '분노',
+    themes: ['자연', '평화', '화해', '즐거움', '기쁨', '사랑'],
+    interactions: ['위로', '카타르시스', '감사', '환희', '감성적'],
+  },
+] as const;

--- a/src/poem/dto/request/get-poems.dto.ts
+++ b/src/poem/dto/request/get-poems.dto.ts
@@ -1,0 +1,10 @@
+import { IsString, IsNumber, IsOptional } from 'class-validator';
+
+export class GetPoemsDto {
+  @IsOptional()
+  @IsString()
+  readonly emotion?: string;
+
+  @IsNumber()
+  readonly index: number;
+}

--- a/src/poem/dto/request/get-poems.dto.ts
+++ b/src/poem/dto/request/get-poems.dto.ts
@@ -1,9 +1,10 @@
-import { IsString, IsNumber, IsOptional } from 'class-validator';
+import { IsNumber, IsOptional, IsEnum } from 'class-validator';
+import { emotions } from 'src/constants/emotions';
 
 export class GetPoemsDto {
   @IsOptional()
-  @IsString()
-  readonly emotion?: string;
+  @IsEnum(emotions.map((emotion) => emotion.emotion))
+  readonly emotion?: (typeof emotions)[number]['emotion'];
 
   @IsNumber()
   readonly index: number;

--- a/src/poem/dto/request/index.ts
+++ b/src/poem/dto/request/index.ts
@@ -1,3 +1,4 @@
 export * from './analyze-poem.dto';
 export * from './update-tag.dto';
 export * from './create-poem.dto';
+export * from './get-poems.dto';

--- a/src/poem/dto/response/index.ts
+++ b/src/poem/dto/response/index.ts
@@ -1,3 +1,4 @@
 export * from './tags.dto';
 export * from './content.dto';
 export * from './new-poem.dto';
+export * from './poem.dto';

--- a/src/poem/dto/response/poem.dto.ts
+++ b/src/poem/dto/response/poem.dto.ts
@@ -1,0 +1,46 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { themes, interactions } from 'src/constants/tags';
+
+export class PoemDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  title: string;
+
+  @ApiProperty()
+  content: string;
+
+  @ApiProperty()
+  textAlign: string;
+
+  @ApiProperty()
+  textSize: number;
+
+  @ApiProperty()
+  textFont: string;
+
+  @ApiProperty({ isArray: true, enum: themes })
+  themes: (typeof themes)[number][];
+
+  @ApiProperty({ isArray: true, enum: interactions })
+  interactions: (typeof interactions)[number][];
+
+  @ApiProperty()
+  isRecorded: boolean;
+
+  @ApiProperty({ nullable: true, type: 'string' })
+  audioUrl: string | null;
+
+  @ApiProperty()
+  createdAt: Date;
+
+  @ApiProperty()
+  inspirationId: string;
+
+  @ApiProperty()
+  authorId: string;
+
+  @ApiProperty({ description: '로그인한 사용자가 스크랩한 시인지 여부' })
+  isScrapped: boolean;
+}

--- a/src/poem/dto/response/poem.dto.ts
+++ b/src/poem/dto/response/poem.dto.ts
@@ -21,10 +21,10 @@ export class PoemDto {
   textFont: string;
 
   @ApiProperty({ isArray: true, enum: themes })
-  themes: (typeof themes)[number][];
+  themes: string[];
 
   @ApiProperty({ isArray: true, enum: interactions })
-  interactions: (typeof interactions)[number][];
+  interactions: string[];
 
   @ApiProperty()
   isRecorded: boolean;

--- a/src/poem/poem.controller.ts
+++ b/src/poem/poem.controller.ts
@@ -80,7 +80,6 @@ export class PoemController {
     @Body() createPoemDto: CreatePoemDto,
     @UploadedFile() audioFile?: Express.Multer.File,
   ) {
-    console.log(audioFile);
     return await this.poemService.create(userId, {
       ...createPoemDto,
       audioFile,

--- a/src/poem/poem.module.ts
+++ b/src/poem/poem.module.ts
@@ -7,9 +7,10 @@ import { LlmService } from './llm.service';
 import { AwsModule } from '../aws/aws.module';
 import { ScrapRepository } from './scrap.repository';
 import { ScrapPrismaRepository } from './scrap.prisma.repository';
+import { TagModule } from 'src/tag/tag.module';
 
 @Module({
-  imports: [AwsModule],
+  imports: [AwsModule, TagModule],
   controllers: [PoemController],
   providers: [
     PoemService,

--- a/src/poem/poem.prisma.repository.ts
+++ b/src/poem/poem.prisma.repository.ts
@@ -69,6 +69,41 @@ export class PoemPrismaRepository implements PoemRepository {
     });
     return;
   }
+
+  async findThreeByIndex({ userId, index }: FindInputWithoutEmotion) {
+    return this.prisma.poem.findMany({
+      take: 3,
+      skip: index * 3,
+      orderBy: {
+        createdAt: 'desc',
+      },
+      where: {
+        status: '출판',
+      },
+      select: {
+        id: true,
+        title: true,
+        content: true,
+        textAlign: true,
+        textSize: true,
+        textFont: true,
+        themes: true,
+        interactions: true,
+        isRecorded: true,
+        inspirationId: true,
+        createdAt: true,
+        authorId: true,
+        scraps: {
+          where: {
+            userId,
+          },
+          select: {
+            id: true,
+          },
+        },
+      },
+    });
+  }
 }
 
 export type CreateInput = {
@@ -84,4 +119,9 @@ export type CreateInput = {
   originalTitle?: string | null;
   inspirationId: string;
   status: string;
+};
+
+export type FindInputWithoutEmotion = {
+  userId: string;
+  index: number;
 };

--- a/src/poem/poem.prisma.repository.ts
+++ b/src/poem/poem.prisma.repository.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
-import { Poem, PoemRepository } from './poem.repository';
+import { PoemRepository, FindInputWithTags } from './poem.repository';
 import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
@@ -96,6 +95,53 @@ export class PoemPrismaRepository implements PoemRepository {
         scraps: {
           where: {
             userId,
+          },
+          select: {
+            id: true,
+          },
+        },
+      },
+    });
+  }
+
+  async findNByTagAndIndex(findInputWithTags: FindInputWithTags) {
+    return this.prisma.poem.findMany({
+      take: findInputWithTags.limit,
+      skip: findInputWithTags.index * findInputWithTags.limit,
+      orderBy: {
+        createdAt: 'desc',
+      },
+      where: {
+        status: '출판',
+        OR: [
+          {
+            themes: {
+              hasSome: findInputWithTags.themes,
+            },
+          },
+          {
+            interactions: {
+              hasSome: findInputWithTags.interactions,
+            },
+          },
+        ],
+      },
+      select: {
+        id: true,
+        title: true,
+        content: true,
+        textAlign: true,
+        textSize: true,
+        textFont: true,
+        themes: true,
+        interactions: true,
+        isRecorded: true,
+        inspirationId: true,
+        createdAt: true,
+        authorId: true,
+        scraps: {
+          where: {
+            userId: findInputWithTags.userId,
           },
           select: {
             id: true,

--- a/src/poem/poem.repository.ts
+++ b/src/poem/poem.repository.ts
@@ -1,12 +1,13 @@
+import { themes, interactions } from '../constants/tags';
+
 export interface PoemRepository {
   create(userId: string, data: CreateInput): Promise<NewPoem>;
   countUserDaily(userId: string): Promise<number>;
   findAllProofreading(): Promise<ProofreadingPoemList>;
   findOneProofreading(id: string): Promise<PoemWithOriginalContent | null>;
   updateStatus(id: string, status: string): Promise<void>;
-  findThreeByIndex(
-    findInputWithoutEmotion: FindInputWithoutEmotion,
-  ): Promise<Poem[]>;
+  findThreeByIndex(findInputWithoutTags: FindInputWithoutTags): Promise<Poem[]>;
+  findNByTagAndIndex(findInputWithTags: FindInputWithTags): Promise<Poem[]>;
 }
 
 export type CreateInput = {
@@ -74,9 +75,17 @@ export type Poem = {
   scraps: { id: string }[];
 };
 
-export type FindInputWithoutEmotion = {
+export type FindInputWithoutTags = {
   userId: string;
   index: number;
+};
+
+export type FindInputWithTags = {
+  userId: string;
+  index: number;
+  limit: number;
+  themes: (typeof themes)[number][];
+  interactions: (typeof interactions)[number][];
 };
 
 export const PoemRepository = Symbol('PoemRepository');

--- a/src/poem/poem.repository.ts
+++ b/src/poem/poem.repository.ts
@@ -1,9 +1,12 @@
 export interface PoemRepository {
-  create(userId: string, data: CreateInput): Promise<Poem>;
+  create(userId: string, data: CreateInput): Promise<NewPoem>;
   countUserDaily(userId: string): Promise<number>;
   findAllProofreading(): Promise<ProofreadingPoemList>;
   findOneProofreading(id: string): Promise<PoemWithOriginalContent | null>;
   updateStatus(id: string, status: string): Promise<void>;
+  findThreeByIndex(
+    findInputWithoutEmotion: FindInputWithoutEmotion,
+  ): Promise<Poem[]>;
 }
 
 export type CreateInput = {
@@ -21,7 +24,7 @@ export type CreateInput = {
   status: string;
 };
 
-export type Poem = {
+export type NewPoem = {
   id: string;
   title: string;
   content: string;
@@ -43,7 +46,7 @@ export type ProofreadingPoemList = {
 }[];
 
 export type PoemWithOriginalContent = Omit<
-  Poem & {
+  NewPoem & {
     originalTitle: string | null;
     originalContent: string | null;
     inspiration: {
@@ -54,5 +57,26 @@ export type PoemWithOriginalContent = Omit<
   },
   'inspirationId'
 >;
+
+export type Poem = {
+  id: string;
+  title: string;
+  content: string;
+  textAlign: string;
+  textSize: number;
+  textFont: string;
+  themes: string[];
+  interactions: string[];
+  isRecorded: boolean;
+  createdAt: Date;
+  inspirationId: string;
+  authorId: string;
+  scraps: { id: string }[];
+};
+
+export type FindInputWithoutEmotion = {
+  userId: string;
+  index: number;
+};
 
 export const PoemRepository = Symbol('PoemRepository');

--- a/src/poem/poem.service.ts
+++ b/src/poem/poem.service.ts
@@ -118,6 +118,27 @@ export class PoemService {
   async publish(id: string) {
     await this.poemRepository.updateStatus(id, '출판');
   }
+
+  async getThree(getPoemsInput: GetPoemsInput) {
+    let poems;
+    if (getPoemsInput.emotion) {
+    }
+    poems = await this.poemRepository.findThreeByIndex({
+      userId: getPoemsInput.userId,
+      index: getPoemsInput.index,
+    });
+
+    return poems.map((poem) => {
+      const { scraps, ...rest } = poem;
+      return {
+        ...rest,
+        isScrapped: scraps.length > 0,
+        audioUrl: rest.isRecorded
+          ? this.awsService.getPoemAudioUrl() + rest.id
+          : null,
+      };
+    });
+  }
 }
 
 export type CreateInput = {
@@ -141,4 +162,10 @@ export type UpdateTagInput = {
   afterThemes: string[];
   afterInteractions: string[];
   content: string;
+};
+
+export type GetPoemsInput = {
+  userId: string;
+  emotion?: string;
+  index: number;
 };

--- a/src/tag/tag.module.ts
+++ b/src/tag/tag.module.ts
@@ -4,6 +4,7 @@ import { TagService } from './tag.service';
 
 @Module({
   controllers: [TagController],
-  providers: [TagService]
+  providers: [TagService],
+  exports: [TagService],
 })
 export class TagModule {}

--- a/src/tag/tag.service.ts
+++ b/src/tag/tag.service.ts
@@ -1,9 +1,18 @@
 import { Injectable } from '@nestjs/common';
-import { themes, interactions } from '../constants/tags';
+import { themes, interactions, firstTags, secondTags } from '../constants/tags';
+import { emotions } from 'src/constants/emotions';
 
 @Injectable()
 export class TagService {
   getAll() {
     return { themes, interactions };
+  }
+
+  getFirstTags(emotion: (typeof emotions)[number]['emotion']) {
+    return firstTags.find((tag) => tag.emotion === emotion);
+  }
+
+  getSecondTags(emotion: (typeof emotions)[number]['emotion']) {
+    return secondTags.find((tag) => tag.emotion === emotion);
   }
 }

--- a/src/tag/tag.service.ts
+++ b/src/tag/tag.service.ts
@@ -9,10 +9,16 @@ export class TagService {
   }
 
   getFirstTags(emotion: (typeof emotions)[number]['emotion']) {
-    return firstTags.find((tag) => tag.emotion === emotion);
+    const { emotion: _, ...rest } = firstTags.find(
+      (tag) => tag.emotion === emotion,
+    )!;
+    return rest;
   }
 
   getSecondTags(emotion: (typeof emotions)[number]['emotion']) {
-    return secondTags.find((tag) => tag.emotion === emotion);
+    const { emotion: _, ...rest } = secondTags.find(
+      (tag) => tag.emotion === emotion,
+    )!;
+    return rest;
   }
 }


### PR DESCRIPTION
## 🏷️ 연관 이슈

- close #43

## ✨ 작업 내용
- 감정이 '모르겠음' 일때는 그냥 최신순으로 3개씩 반환
- 감정이 있을 땐 1차 태그 2개, 2차 태그 1개 총 3개씩 반환
- E2E Test
  - 감정이 없을 때도 시를 3개씩 받을 수 있고, 상태가 출판인 시만 반환한다
  - 스크랩한 시인 경우 isScrapped가 true로 반환된다
  - 감정이 슬픔일 때, 슬픔에 알맞은 시를 3개씩 받을 수 있다
  - 시가 있더라도 감정에 맞는 시가 없을 때는 빈 배열을 반환한다
  - 허용된 감정이 아닌 경우 400 에러를 반환한다