### PR TITLE
프로필 정보 조회 기능 구현

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,10 +21,12 @@ enum InspirationType {
 }
 
 model User {
-  id         String   @id @default(uuid())
-  provider   Provider
-  providerId String
-  name       String
+  id           String   @id @default(uuid())
+  provider     Provider
+  providerId   String
+  name         String
+  introduction String?
+  ink          Int      @default(0)
 
   mainAchievementId String?
   mainAchievement   Achievement?             @relation(fields: [mainAchievementId], references: [id])

--- a/src/poem/scrap.prisma.repository.ts
+++ b/src/poem/scrap.prisma.repository.ts
@@ -27,7 +27,7 @@ export class ScrapPrismaRepository implements ScrapRepository {
     });
   }
 
-  async findBestScrapperByUserId(authorId: string) {
+  async findBestScrapUsersByAuthorId(authorId: string) {
     const result = await this.prisma.$queryRaw<
       { id: string; name: string; icon: string; count: BigInt }[]
     >`

--- a/src/poem/scrap.prisma.repository.ts
+++ b/src/poem/scrap.prisma.repository.ts
@@ -27,6 +27,7 @@ export class ScrapPrismaRepository implements ScrapRepository {
     });
   }
 
+  // TODO 쿼리 빌더 추가되면 변경하기.
   async findBestScrapUsersByAuthorId(authorId: string) {
     const result = await this.prisma.$queryRaw<
       { id: string; name: string; icon: string; count: BigInt }[]

--- a/src/poem/scrap.prisma.repository.ts
+++ b/src/poem/scrap.prisma.repository.ts
@@ -28,7 +28,7 @@ export class ScrapPrismaRepository implements ScrapRepository {
   }
 
   async findBestScrapperByUserId(authorId: string) {
-    return await this.prisma.$queryRaw<
+    const result = await this.prisma.$queryRaw<
       { id: string; name: string; icon: string; count: BigInt }[]
     >`
     SELECT u.id, u.name, a.icon, COUNT(s.id)
@@ -40,9 +40,8 @@ export class ScrapPrismaRepository implements ScrapRepository {
     GROUP BY u.id, u.name, a.icon
     ORDER BY count DESC
     LIMIT 10;
-  `.then((list) =>
-      list.map((data) => ({ ...data, count: Number(data.count) })),
-    );
+  `;
+    return result.map((data) => ({ ...data, count: Number(data.count) }));
   }
 
   async delete(id: string): Promise<void> {

--- a/src/poem/scrap.repository.ts
+++ b/src/poem/scrap.repository.ts
@@ -7,7 +7,7 @@ export interface ScrapRepository {
     userId: string,
   ): Promise<Scrap | null>;
   delete(id: string): Promise<void>;
-  findBestScrapperByUserId(userId: string): Promise<ScrapUser[]>;
+  findBestScrapUsersByAuthorId(userId: string): Promise<ScrapUser[]>;
 }
 
 export type Scrap = {

--- a/src/poem/scrap.repository.ts
+++ b/src/poem/scrap.repository.ts
@@ -7,6 +7,7 @@ export interface ScrapRepository {
     userId: string,
   ): Promise<Scrap | null>;
   delete(id: string): Promise<void>;
+  findBestScrapperByUserId(userId: string): Promise<ScrapUser[]>;
 }
 
 export type Scrap = {
@@ -15,5 +16,7 @@ export type Scrap = {
   poemId: string;
   createdAt: Date;
 };
+
+type ScrapUser = { id: string; name: string; icon: string; count: number };
 
 export const ScrapRepository = Symbol('ScrapRepository');

--- a/src/user/dto/response/profile.ts
+++ b/src/user/dto/response/profile.ts
@@ -1,0 +1,58 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+class Achievement {
+  @ApiProperty()
+  readonly id: string;
+
+  @ApiProperty()
+  readonly name: string;
+
+  @ApiProperty()
+  readonly icon: string;
+
+  @ApiProperty()
+  readonly description: string;
+}
+
+class ScrapUser {
+  @ApiProperty()
+  readonly id: string;
+
+  @ApiProperty()
+  readonly name: string;
+
+  @ApiProperty({
+    type: 'string',
+    nullable: true,
+    description: '대표 업적 icon URL',
+  })
+  readonly icon?: string | null;
+
+  @ApiProperty()
+  readonly count: number;
+}
+
+export class ProfileDto {
+  @ApiProperty()
+  readonly id: string;
+
+  @ApiProperty()
+  readonly name: string;
+
+  @ApiProperty()
+  readonly ink: number;
+
+  @ApiProperty({ type: 'string', nullable: true })
+  @ApiPropertyOptional()
+  readonly introduction?: string | null;
+
+  @ApiProperty({ type: Achievement, nullable: true })
+  @ApiPropertyOptional()
+  readonly mainAchievement?: Achievement | null;
+
+  @ApiProperty({ isArray: true, type: Achievement })
+  readonly achievements: Achievement[];
+
+  @ApiProperty({ isArray: true, type: ScrapUser })
+  readonly scrapUsers: ScrapUser[];
+}

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,4 +1,10 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  HttpException,
+  HttpStatus,
+  UseGuards,
+} from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiOperation,
@@ -24,6 +30,17 @@ export class UserController {
   @ApiResponse({ status: 200, type: ProfileDto })
   @Get('profile')
   async getOneDetailById(@CurrentUser() userId: string): Promise<ProfileDto> {
-    return await this.userService.getOneDetailById(userId);
+    try {
+      return await this.userService.getOneDetailById(userId);
+    } catch (e: unknown) {
+      if (e instanceof Error) {
+        if (e.message === 'user not found') {
+          throw new HttpException(e.message, HttpStatus.BAD_REQUEST);
+        } else {
+          throw new HttpException(e.message, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+      }
+      throw e;
+    }
   }
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -17,7 +17,10 @@ import { ProfileDto } from './dto/response/profile';
 export class UserController {
   constructor(private readonly userService: UserService) {}
 
-  @ApiOperation({ summary: '자신의 프로필 정보 조회', description: '' })
+  @ApiOperation({
+    summary: '자신의 프로필 정보 조회',
+    description: '프로필 정보와 최다 스크랩 유저 10명을 조회합니다.',
+  })
   @ApiResponse({ status: 200, type: ProfileDto })
   @Get('profile')
   async getOneDetailById(@CurrentUser() userId: string): Promise<ProfileDto> {

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -36,7 +36,7 @@ export class UserController {
     } catch (e: unknown) {
       if (e instanceof Error) {
         if (e.message === 'user not found') {
-          throw new HttpException(e.message, HttpStatus.NOT_ACCEPTABLE);
+          throw new HttpException(e.message, HttpStatus.NOT_FOUND);
         } else {
           throw new HttpException(e.message, HttpStatus.INTERNAL_SERVER_ERROR);
         }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,7 +1,26 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { UserService } from './user.service';
+import { CurrentUser } from '../common/decorators';
+import { JwtGuard } from '../auth/guards';
+import { ProfileDto } from './dto/response/profile';
 
+@ApiTags('user')
+@ApiBearerAuth()
+@UseGuards(JwtGuard)
 @Controller('user')
 export class UserController {
   constructor(private readonly userService: UserService) {}
+
+  @ApiOperation({ summary: '자신의 프로필 정보 조회', description: '' })
+  @ApiResponse({ status: 200, type: ProfileDto })
+  @Get('profile')
+  async getOneDetailById(@CurrentUser() userId: string): Promise<ProfileDto> {
+    return await this.userService.getOneDetailById(userId);
+  }
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -28,6 +28,7 @@ export class UserController {
     description: '프로필 정보와 최다 스크랩 유저 10명을 조회합니다.',
   })
   @ApiResponse({ status: 200, type: ProfileDto })
+  @ApiResponse({ status: 404, description: 'user not found' })
   @Get('profile')
   async getOneDetailById(@CurrentUser() userId: string): Promise<ProfileDto> {
     try {
@@ -35,7 +36,7 @@ export class UserController {
     } catch (e: unknown) {
       if (e instanceof Error) {
         if (e.message === 'user not found') {
-          throw new HttpException(e.message, HttpStatus.BAD_REQUEST);
+          throw new HttpException(e.message, HttpStatus.NOT_ACCEPTABLE);
         } else {
           throw new HttpException(e.message, HttpStatus.INTERNAL_SERVER_ERROR);
         }

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -3,6 +3,8 @@ import { UserService } from './user.service';
 import { UserRepository } from './user.repository';
 import { UserPrismaRepository } from './user.prisma.repository';
 import { UserController } from './user.controller';
+import { ScrapRepository } from '../poem/scrap.repository';
+import { ScrapPrismaRepository } from '../poem/scrap.prisma.repository';
 
 @Module({
   controllers: [UserController],
@@ -11,6 +13,10 @@ import { UserController } from './user.controller';
     {
       provide: UserRepository,
       useClass: UserPrismaRepository,
+    },
+    {
+      provide: ScrapRepository,
+      useClass: ScrapPrismaRepository,
     },
   ],
   exports: [UserRepository],

--- a/src/user/user.prisma.repository.ts
+++ b/src/user/user.prisma.repository.ts
@@ -17,44 +17,42 @@ export class UserPrismaRepository implements UserRepository {
   }
 
   async findOneDetailById(id: string) {
-    return this.prisma.user
-      .findUnique({
-        where: { id },
-        select: {
-          id: true,
-          name: true,
-          ink: true,
-          introduction: true,
-          mainAchievement: {
-            select: {
-              id: true,
-              name: true,
-              icon: true,
-              description: true,
-            },
+    const result = await this.prisma.user.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        name: true,
+        ink: true,
+        introduction: true,
+        mainAchievement: {
+          select: {
+            id: true,
+            name: true,
+            icon: true,
+            description: true,
           },
-          achievements: {
-            select: {
-              achievement: {
-                select: {
-                  id: true,
-                  name: true,
-                  icon: true,
-                  description: true,
-                },
+        },
+        achievements: {
+          select: {
+            achievement: {
+              select: {
+                id: true,
+                name: true,
+                icon: true,
+                description: true,
               },
             },
           },
         },
-      })
-      .then((data) =>
-        data
-          ? {
-              ...data,
-              achievements: data.achievements.map((a) => a.achievement),
-            }
-          : null,
-      );
+      },
+    });
+
+    return result
+      ? {
+          ...result,
+          achievements: result.achievements.map((a) => a.achievement),
+        }
+      : null;
   }
 
   async create({

--- a/src/user/user.prisma.repository.ts
+++ b/src/user/user.prisma.repository.ts
@@ -16,6 +16,47 @@ export class UserPrismaRepository implements UserRepository {
     });
   }
 
+  async findOneDetailById(id: string) {
+    return this.prisma.user
+      .findUnique({
+        where: { id },
+        select: {
+          id: true,
+          name: true,
+          ink: true,
+          introduction: true,
+          mainAchievement: {
+            select: {
+              id: true,
+              name: true,
+              icon: true,
+              description: true,
+            },
+          },
+          achievements: {
+            select: {
+              achievement: {
+                select: {
+                  id: true,
+                  name: true,
+                  icon: true,
+                  description: true,
+                },
+              },
+            },
+          },
+        },
+      })
+      .then((data) =>
+        data
+          ? {
+              ...data,
+              achievements: data.achievements.map((a) => a.achievement),
+            }
+          : null,
+      );
+  }
+
   async create({
     provider,
     providerId,

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -9,6 +9,8 @@ export interface UserRepository {
     name: string;
   } | null>;
 
+  findOneDetailById(id: string): Promise<User | null>;
+
   create({
     provider,
     providerId,
@@ -24,5 +26,21 @@ export interface UserRepository {
     name: string;
   }>;
 }
+
+type Achievement = {
+  id: string;
+  name: string;
+  icon: string;
+  description: string;
+};
+
+type User = {
+  id: string;
+  name: string;
+  ink: number;
+  introduction?: string | null;
+  mainAchievement?: Achievement | null;
+  achievements: Achievement[];
+};
 
 export const UserRepository = Symbol('UserRepository');

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,10 +1,25 @@
 import { Injectable, Inject } from '@nestjs/common';
 import { UserRepository } from './user.repository';
+import { ScrapRepository } from '../poem/scrap.repository';
 
 @Injectable()
 export class UserService {
   constructor(
     @Inject(UserRepository)
     private readonly userRepository: UserRepository,
+    @Inject(ScrapRepository)
+    private readonly scrapRepository: ScrapRepository,
   ) {}
+
+  async getOneDetailById(id: string) {
+    const user = await this.userRepository.findOneDetailById(id);
+    if (!user) throw Error('user not found');
+
+    const scrapUsers = await this.scrapRepository.findBestScrapperByUserId(id);
+
+    return {
+      ...user,
+      scrapUsers,
+    };
+  }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -14,7 +14,8 @@ export class UserService {
   async getOneDetailById(id: string) {
     const user = await this.userRepository.findOneDetailById(id);
     if (!user) throw Error('user not found');
-    const scrapUsers = await this.scrapRepository.findBestScrapperByUserId(id);
+    const scrapUsers =
+      await this.scrapRepository.findBestScrapUsersByAuthorId(id);
 
     return {
       ...user,

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -14,7 +14,6 @@ export class UserService {
   async getOneDetailById(id: string) {
     const user = await this.userRepository.findOneDetailById(id);
     if (!user) throw Error('user not found');
-
     const scrapUsers = await this.scrapRepository.findBestScrapperByUserId(id);
 
     return {

--- a/test/e2e/helpers/generate-create-data.ts
+++ b/test/e2e/helpers/generate-create-data.ts
@@ -1,0 +1,51 @@
+export const createAchievementData = (
+  name: string,
+  icon: string = 'https://icon.com',
+  description: string = '획득 조건',
+) => {
+  return {
+    name,
+    icon,
+    description,
+  };
+};
+
+export const createUserData = (
+  name: string,
+  providerId: string,
+  provider: 'GOOGLE' | 'APPLE' = 'GOOGLE',
+) => {
+  return {
+    name,
+    providerId,
+    provider,
+  };
+};
+
+export const createPoemData = (
+  authorId: string,
+  inspirationId: string,
+  title: string = 'test-poem',
+  content: string = 'test-content',
+  textAlign: string = 'test-align',
+  textSize: number = 16,
+  textFont: string = 'test-font',
+  themes: string[] = [],
+  interactions: string[] = [],
+  isRecorded: boolean = false,
+  status: string = 'test-status',
+) => {
+  return {
+    title,
+    content,
+    textAlign,
+    textSize,
+    textFont,
+    themes,
+    interactions,
+    isRecorded,
+    status,
+    inspirationId,
+    authorId,
+  };
+};

--- a/test/e2e/helpers/index.ts
+++ b/test/e2e/helpers/index.ts
@@ -1,1 +1,2 @@
 export * from './login';
+export * from './generate-create-data';

--- a/test/e2e/user.e2e-spec.ts
+++ b/test/e2e/user.e2e-spec.ts
@@ -1,0 +1,162 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { describe } from 'node:test';
+import { AuthService } from 'src/auth/auth.service';
+import { AppModule } from 'src/app.module';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { login } from './helpers/login';
+import {
+  createAchievementData,
+  createPoemData,
+  createUserData,
+} from './helpers';
+
+describe('User (e2e)', () => {
+  let app: INestApplication;
+  let authService: AuthService;
+  let prisma: PrismaService;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    prisma = moduleFixture.get<PrismaService>(PrismaService);
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    authService = moduleFixture.get<AuthService>(AuthService);
+    jest.spyOn(authService, 'getGoogleProfile').mockResolvedValue({
+      id: 'test-id',
+      email: 'test@test.com',
+      picture: 'https://picture.com',
+      verified_email: true,
+    });
+  });
+
+  afterEach(async () => {
+    await prisma.achievementAcquisition.deleteMany();
+    await prisma.achievement.deleteMany();
+    await prisma.scrap.deleteMany();
+    await prisma.poem.deleteMany();
+    await prisma.inspiration.deleteMany();
+    await prisma.user.deleteMany();
+  });
+
+  describe('GET /user/profile - 프로필 정보 조회', async () => {
+    it('프로필 정보 조회', async () => {
+      // given
+      const { accessToken, name } = await login(app);
+      const user = await prisma.user.findFirst({
+        where: { name },
+      });
+
+      const otherUser1 = await prisma.user.create({
+        data: createUserData('other-user1', 'test-id1'),
+      });
+      const otherUser2 = await prisma.user.create({
+        data: createUserData('other-user2', 'test-id2'),
+      });
+
+      const achievement1 = await prisma.achievement.create({
+        data: createAchievementData('멋진 업적'),
+      });
+      const achievement2 = await prisma.achievement.create({
+        data: createAchievementData('더 멋진 업적'),
+      });
+
+      await prisma.achievementAcquisition.create({
+        data: {
+          userId: user!.id,
+          achievementId: achievement1.id,
+        },
+      });
+
+      await prisma.user.update({
+        where: { id: user!.id },
+        data: {
+          mainAchievementId: achievement1.id,
+        },
+      });
+
+      const titleInspiration = await prisma.inspiration.create({
+        data: {
+          type: 'TITLE',
+          displayName: 'test-title',
+        },
+      });
+
+      const poem1 = await prisma.poem.create({
+        data: createPoemData(user!.id, titleInspiration.id),
+      });
+      const poem2 = await prisma.poem.create({
+        data: createPoemData(user!.id, titleInspiration.id),
+      });
+
+      const scrap1 = await prisma.scrap.create({
+        data: {
+          userId: otherUser1.id,
+          poemId: poem1.id,
+        },
+      });
+
+      const scrap2 = await prisma.scrap.create({
+        data: {
+          userId: otherUser1.id,
+          poemId: poem2.id,
+        },
+      });
+
+      const scrap3 = await prisma.scrap.create({
+        data: {
+          userId: otherUser2.id,
+          poemId: poem2.id,
+        },
+      });
+
+      // when
+      const response = await request(app.getHttpServer())
+        .get(`/user/profile`)
+        .set('Authorization', `Bearer ${accessToken}`);
+      const { status, body } = response;
+
+      // then
+      expect(status).toEqual(200);
+      expect(body).toMatchObject({
+        id: user!.id,
+        name: 'test',
+        ink: 0,
+        introduction: null,
+        mainAchievement: {
+          id: achievement1.id,
+          name: '멋진 업적',
+          icon: 'https://icon.com',
+          description: '획득 조건',
+        },
+        achievements: [
+          {
+            id: achievement1.id,
+            name: '멋진 업적',
+            icon: 'https://icon.com',
+            description: '획득 조건',
+          },
+        ],
+        scrapUsers: [
+          {
+            id: otherUser1.id,
+            name: 'other-user1',
+            icon: null,
+            count: 2,
+          },
+          {
+            id: otherUser2.id,
+            name: 'other-user2',
+            icon: null,
+            count: 1,
+          },
+        ],
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 🏷️ 연관 이슈
- #44 
## ✨ 작업 내용
- user 테이블에 잉크, 소개 컬럼 추가
- 테스트 데이터 생성 함수 구현
- 프로필 조회 기능 구현
## 🗣️  고려 사항
- 스크랩 많이한 회원 조회를 scrap repo에 로우 쿼리로 분리하고, userService에서 회원 정보 조회랑 합쳐서 반환 중입니다.
- 로우 쿼리로 count를 하니까 big int 타입으로 나오던데, 스크랩 횟수가 항상 js의 number 타입이 커버할 수 있는 범위 내의 값일 거 같아서 number로 변환하고 반환했어요.