### PR TITLE
[관리자] 교정중인 시 리스트 전체 조회

### DIFF
--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -20,7 +20,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import { UploadInspirationDto, GetInspirationsDto } from './dto/request';
 import {
   ProofreadingPoemDto,
-  ProofreadingPoemDetailDto,
+  // ProofreadingPoemDetailDto,
   TitleInspirationDto,
   WordInspirationDto,
   AudioInspirationDto,
@@ -61,21 +61,21 @@ export class AdminController {
   @ApiOperation({ summary: '교정중인 시 목록 조회 (탈고만 된거)' })
   @ApiResponse({ status: 200, type: [ProofreadingPoemDto] })
   @Get('poems/proofreading')
-  async findAllProofreading() {
+  async findAllProofreading(): Promise<ProofreadingPoemDto[]> {
     return await this.poemService.getProofreadingList();
   }
 
-  @ApiOperation({ summary: '교정중인 시 조회' })
-  @ApiResponse({
-    status: 200,
-    type: ProofreadingPoemDetailDto,
-  })
-  @Get('poems/proofreading/:id')
-  async findOneProofreading(
-    @Param('id') id: string,
-  ): Promise<ProofreadingPoemDetailDto> {
-    return await this.poemService.getOneProofreading(id);
-  }
+  // @ApiOperation({ summary: '교정중인 시 조회' })
+  // @ApiResponse({
+  //   status: 200,
+  //   type: ProofreadingPoemDetailDto,
+  // })
+  // @Get('poems/proofreading/:id')
+  // async findOneProofreading(
+  //   @Param('id') id: string,
+  // ): Promise<ProofreadingPoemDetailDto> {
+  //   return await this.poemService.getOneProofreading(id);
+  // }
 
   @ApiOperation({ summary: '출판' })
   @ApiResponse({ status: 200, description: '출판 성공' })

--- a/src/admin/dto/response/audio-inspiration.dto.ts
+++ b/src/admin/dto/response/audio-inspiration.dto.ts
@@ -5,6 +5,9 @@ export class AudioInspirationDto {
   id: string;
 
   @ApiProperty()
+  type: string;
+
+  @ApiProperty()
   filename: string;
 
   @ApiProperty()

--- a/src/admin/dto/response/index.ts
+++ b/src/admin/dto/response/index.ts
@@ -1,5 +1,5 @@
-export * from './proofreading-poem-list.dto';
 export * from './proofreading-poem.dto';
+// export * from './proofreading-poem-detail.dto';
 export * from './title-inspiration.dto';
 export * from './word-inspiration.dto';
 export * from './audio-inspiration.dto';

--- a/src/admin/dto/response/proofreading-poem-detail.dto.ts
+++ b/src/admin/dto/response/proofreading-poem-detail.dto.ts
@@ -1,0 +1,120 @@
+// import { ApiProperty, getSchemaPath, ApiExtraModels } from '@nestjs/swagger';
+// import { themes, interactions } from 'src/constants/tags';
+
+// class TitleInspirationDto {
+//   @ApiProperty()
+//   readonly id: string;
+
+//   @ApiProperty()
+//   readonly type: 'TITLE';
+
+//   @ApiProperty()
+//   readonly title: string;
+// }
+
+// class WordInspirationDto {
+//   @ApiProperty()
+//   readonly id: string;
+
+//   @ApiProperty()
+//   readonly type: 'WORD';
+
+//   @ApiProperty()
+//   readonly word: string;
+// }
+
+// class AudioInspirationDto {
+//   @ApiProperty()
+//   readonly id: string;
+
+//   @ApiProperty()
+//   readonly type: 'AUDIO';
+
+//   @ApiProperty()
+//   readonly filename: string;
+
+//   @ApiProperty()
+//   readonly audioUrl: string;
+// }
+
+// class VideoInspirationDto {
+//   @ApiProperty()
+//   readonly id: string;
+
+//   @ApiProperty()
+//   readonly type: 'VIDEO';
+
+//   @ApiProperty()
+//   readonly filename: string;
+
+//   @ApiProperty()
+//   readonly videoUrl: string;
+// }
+
+// @ApiExtraModels(
+//   TitleInspirationDto,
+//   WordInspirationDto,
+//   AudioInspirationDto,
+//   VideoInspirationDto,
+// )
+// export class ProofreadingPoemDetailDto {
+//   @ApiProperty()
+//   readonly id: string;
+
+//   @ApiProperty()
+//   readonly title: string;
+
+//   @ApiProperty()
+//   readonly content: string;
+
+//   @ApiProperty()
+//   readonly textAlign: string;
+
+//   @ApiProperty()
+//   readonly textSize: number;
+
+//   @ApiProperty()
+//   readonly textFont: string;
+
+//   @ApiProperty({ isArray: true, enum: themes })
+//   readonly themes: string[];
+
+//   @ApiProperty({ isArray: true, enum: interactions })
+//   readonly interactions: string[];
+
+//   @ApiProperty()
+//   readonly isRecorded: boolean;
+
+//   @ApiProperty({ required: false })
+//   readonly audioUrl?: string;
+
+//   @ApiProperty()
+//   readonly status: string;
+
+//   @ApiProperty({ type: 'string', nullable: true })
+//   readonly originalContent: string | null;
+
+//   @ApiProperty({ type: 'string', nullable: true })
+//   readonly originalTitle: string | null;
+
+//   @ApiProperty({ description: 'ISO 8601' })
+//   readonly createdAt: Date;
+
+//   @ApiProperty({
+//     oneOf: [
+//       { $ref: getSchemaPath(TitleInspirationDto) },
+//       { $ref: getSchemaPath(WordInspirationDto) },
+//       { $ref: getSchemaPath(AudioInspirationDto) },
+//       { $ref: getSchemaPath(VideoInspirationDto) },
+//     ],
+//     discriminator: { propertyName: 'type' },
+//   })
+//   readonly inspiration:
+//     | TitleInspirationDto
+//     | WordInspirationDto
+//     | AudioInspirationDto
+//     | VideoInspirationDto;
+
+//   @ApiProperty()
+//   readonly authorId: string;
+// }

--- a/src/admin/dto/response/proofreading-poem-list.dto.ts
+++ b/src/admin/dto/response/proofreading-poem-list.dto.ts
@@ -1,9 +1,0 @@
-import { ApiProperty } from '@nestjs/swagger';
-
-export class ProofreadingPoemDto {
-  @ApiProperty()
-  readonly id: string;
-
-  @ApiProperty()
-  readonly title: string;
-}

--- a/src/admin/dto/response/proofreading-poem.dto.ts
+++ b/src/admin/dto/response/proofreading-poem.dto.ts
@@ -57,7 +57,7 @@ class VideoInspirationDto {
   AudioInspirationDto,
   VideoInspirationDto,
 )
-export class ProofreadingPoemDetailDto {
+export class ProofreadingPoemDto {
   @ApiProperty()
   readonly id: string;
 
@@ -65,16 +65,7 @@ export class ProofreadingPoemDetailDto {
   readonly title: string;
 
   @ApiProperty()
-  readonly content: string;
-
-  @ApiProperty()
-  readonly textAlign: string;
-
-  @ApiProperty()
-  readonly textSize: number;
-
-  @ApiProperty()
-  readonly textFont: string;
+  readonly authorName: string;
 
   @ApiProperty({ isArray: true, enum: themes })
   readonly themes: string[];
@@ -85,20 +76,17 @@ export class ProofreadingPoemDetailDto {
   @ApiProperty()
   readonly isRecorded: boolean;
 
-  @ApiProperty({ required: false })
-  readonly audioUrl?: string;
+  @ApiProperty()
+  readonly createdAt: Date;
 
   @ApiProperty()
   readonly status: string;
 
-  @ApiProperty({ type: 'string', nullable: true })
-  readonly originalContent: string | null;
+  @ApiProperty()
+  readonly content: string;
 
-  @ApiProperty({ type: 'string', nullable: true })
-  readonly originalTitle: string | null;
-
-  @ApiProperty({ description: 'ISO 8601' })
-  readonly createdAt: Date;
+  @ApiProperty({ nullable: true })
+  readonly audioUrl: string | null;
 
   @ApiProperty({
     oneOf: [
@@ -107,14 +95,10 @@ export class ProofreadingPoemDetailDto {
       { $ref: getSchemaPath(AudioInspirationDto) },
       { $ref: getSchemaPath(VideoInspirationDto) },
     ],
-    discriminator: { propertyName: 'type' },
   })
   readonly inspiration:
     | TitleInspirationDto
     | WordInspirationDto
     | AudioInspirationDto
     | VideoInspirationDto;
-
-  @ApiProperty()
-  readonly authorId: string;
 }

--- a/src/admin/dto/response/title-inspiration.dto.ts
+++ b/src/admin/dto/response/title-inspiration.dto.ts
@@ -5,5 +5,8 @@ export class TitleInspirationDto {
   id: string;
 
   @ApiProperty()
+  type: string;
+
+  @ApiProperty()
   title: string;
 }

--- a/src/admin/dto/response/video-inspiration.dto.ts
+++ b/src/admin/dto/response/video-inspiration.dto.ts
@@ -5,6 +5,9 @@ export class VideoInspirationDto {
   id: string;
 
   @ApiProperty()
+  type: string;
+
+  @ApiProperty()
   filename: string;
 
   @ApiProperty()

--- a/src/admin/dto/response/word-inspiration.dto.ts
+++ b/src/admin/dto/response/word-inspiration.dto.ts
@@ -5,5 +5,8 @@ export class WordInspirationDto {
   id: string;
 
   @ApiProperty()
+  type: string;
+
+  @ApiProperty()
   word: string;
 }

--- a/src/inspiration/inspiration.prisma.repository.ts
+++ b/src/inspiration/inspiration.prisma.repository.ts
@@ -14,6 +14,7 @@ export class InspirationPrismaRepository implements InspirationRepository {
     });
     return result.map((item) => ({
       id: item.id,
+      type: item.type,
       title: item.displayName,
     }));
   }
@@ -26,6 +27,7 @@ export class InspirationPrismaRepository implements InspirationRepository {
     });
     return result.map((item) => ({
       id: item.id,
+      type: item.type,
       word: item.displayName,
     }));
   }
@@ -38,6 +40,7 @@ export class InspirationPrismaRepository implements InspirationRepository {
     });
     return result.map((item) => ({
       id: item.id,
+      type: item.type,
       filename: item.displayName,
     }));
   }
@@ -50,6 +53,7 @@ export class InspirationPrismaRepository implements InspirationRepository {
     });
     return result.map((item) => ({
       id: item.id,
+      type: item.type,
       filename: item.displayName,
     }));
   }

--- a/src/inspiration/inspiration.repository.ts
+++ b/src/inspiration/inspiration.repository.ts
@@ -1,8 +1,8 @@
 export interface InspirationRepository {
-  findAllTitles(): Promise<{ id: string; title: string }[]>;
-  findAllWords(): Promise<{ id: string; word: string }[]>;
-  findAllAudios(): Promise<{ id: string; filename: string }[]>;
-  findAllVideos(): Promise<{ id: string; filename: string }[]>;
+  findAllTitles(): Promise<{ id: string; type: string; title: string }[]>;
+  findAllWords(): Promise<{ id: string; type: string; word: string }[]>;
+  findAllAudios(): Promise<{ id: string; type: string; filename: string }[]>;
+  findAllVideos(): Promise<{ id: string; type: string; filename: string }[]>;
   createTitle(title: string): Promise<void>;
   createWord(word: string): Promise<void>;
   createAudio(filename: string): Promise<void>;

--- a/src/inspiration/inspiration.service.ts
+++ b/src/inspiration/inspiration.service.ts
@@ -121,6 +121,7 @@ export class InspirationService {
     const audios = await this.inspirationRepository.findAllAudios();
     return audios.map((audio) => ({
       id: audio.id,
+      type: audio.type,
       filename: audio.filename,
       audioUrl: this.awsService.getAudioInspirationUrl() + audio.filename,
     }));
@@ -130,6 +131,7 @@ export class InspirationService {
     const videos = await this.inspirationRepository.findAllVideos();
     return videos.map((video) => ({
       id: video.id,
+      type: video.type,
       filename: video.filename,
       videoUrl: this.awsService.getVideoInspirationUrl() + video.filename,
     }));

--- a/src/poem/poem.prisma.repository.ts
+++ b/src/poem/poem.prisma.repository.ts
@@ -39,6 +39,24 @@ export class PoemPrismaRepository implements PoemRepository {
       select: {
         id: true,
         title: true,
+        author: {
+          select: {
+            name: true,
+          },
+        },
+        themes: true,
+        interactions: true,
+        isRecorded: true,
+        createdAt: true,
+        status: true,
+        content: true,
+        inspiration: {
+          select: {
+            id: true,
+            type: true,
+            displayName: true,
+          },
+        },
       },
     });
   }

--- a/src/poem/poem.repository.ts
+++ b/src/poem/poem.repository.ts
@@ -44,6 +44,20 @@ export type NewPoem = {
 export type ProofreadingPoemList = {
   id: string;
   title: string;
+  author: {
+    name: string;
+  };
+  themes: string[];
+  interactions: string[];
+  isRecorded: boolean;
+  createdAt: Date;
+  status: string;
+  content: string;
+  inspiration: {
+    id: string;
+    type: 'TITLE' | 'WORD' | 'AUDIO' | 'VIDEO';
+    displayName: string;
+  };
 }[];
 
 export type PoemWithOriginalContent = Omit<

--- a/src/poem/poem.service.ts
+++ b/src/poem/poem.service.ts
@@ -79,7 +79,48 @@ export class PoemService {
   }
 
   async getProofreadingList() {
-    return await this.poemRepository.findAllProofreading();
+    const peomList = await this.poemRepository.findAllProofreading();
+    return peomList.map((poem) => {
+      const { inspiration, author, ...rest } = poem;
+      let inspirationData;
+      if (inspiration.type === 'TITLE') {
+        inspirationData = {
+          id: inspiration.id,
+          type: inspiration.type,
+          title: inspiration.displayName,
+        };
+      } else if (inspiration.type === 'WORD') {
+        inspirationData = {
+          id: inspiration.id,
+          type: inspiration.type,
+          word: inspiration.displayName,
+        };
+      } else if (inspiration.type === 'AUDIO') {
+        inspirationData = {
+          id: inspiration.id,
+          type: inspiration.type,
+          filename: inspiration.displayName,
+          audioUrl:
+            this.awsService.getAudioInspirationUrl() + inspiration.displayName,
+        };
+      } else {
+        inspirationData = {
+          id: inspiration.id,
+          type: inspiration.type,
+          filename: inspiration.displayName,
+          videoUrl:
+            this.awsService.getVideoInspirationUrl() + inspiration.displayName,
+        };
+      }
+      return {
+        ...rest,
+        authorName: author.name,
+        inspiration: inspirationData,
+        audioUrl: rest.isRecorded
+          ? this.awsService.getPoemAudioUrl() + rest.id
+          : null,
+      };
+    });
   }
 
   async getOneProofreading(id: string) {

--- a/test/e2e/admin.e2e-spec.ts
+++ b/test/e2e/admin.e2e-spec.ts
@@ -205,7 +205,6 @@ describe('Admin (e2e)', () => {
       expect(body[1].title).toBeDefined();
       expect(body[1].authorName).toBeDefined();
       expect(body[1].themes).toBeDefined();
-      console.log(body);
     });
   });
 

--- a/test/e2e/admin.e2e-spec.ts
+++ b/test/e2e/admin.e2e-spec.ts
@@ -202,90 +202,92 @@ describe('Admin (e2e)', () => {
       // then
       expect(status).toBe(200);
       expect(body).toHaveLength(2);
-      expect(body[0].title).toBe(testData[0].title);
-      expect(body[1].title).toBe(testData[1].title);
+      expect(body[1].title).toBeDefined();
+      expect(body[1].authorName).toBeDefined();
+      expect(body[1].themes).toBeDefined();
+      console.log(body);
     });
   });
 
-  describe('GET /admin/poems/proofreading/:id - 교정중인 시 조회', () => {
-    it('시에 낭독 데이터가 있으면 audioUrl을 포함해서 반환한다.', async () => {
-      // given
-      const { accessToken, name } = await login(app);
-      const user = await prisma.user.findFirst({
-        where: { name },
-      });
-      const inspiration = await prisma.inspiration.create({
-        data: {
-          type: 'TITLE',
-          displayName: 'test-title',
-        },
-      });
-      const poem = await prisma.poem.create({
-        data: {
-          title: 'test-title',
-          content: 'test-content',
-          themes: ['test-theme'],
-          interactions: ['test-interaction'],
-          textAlign: 'center',
-          textSize: 16,
-          textFont: 'test-font',
-          isRecorded: true,
-          inspirationId: inspiration.id,
-          status: '교정중',
-          authorId: user!.id,
-        },
-      });
+  // describe('GET /admin/poems/proofreading/:id - 교정중인 시 조회', () => {
+  //   it('시에 낭독 데이터가 있으면 audioUrl을 포함해서 반환한다.', async () => {
+  //     // given
+  //     const { accessToken, name } = await login(app);
+  //     const user = await prisma.user.findFirst({
+  //       where: { name },
+  //     });
+  //     const inspiration = await prisma.inspiration.create({
+  //       data: {
+  //         type: 'TITLE',
+  //         displayName: 'test-title',
+  //       },
+  //     });
+  //     const poem = await prisma.poem.create({
+  //       data: {
+  //         title: 'test-title',
+  //         content: 'test-content',
+  //         themes: ['test-theme'],
+  //         interactions: ['test-interaction'],
+  //         textAlign: 'center',
+  //         textSize: 16,
+  //         textFont: 'test-font',
+  //         isRecorded: true,
+  //         inspirationId: inspiration.id,
+  //         status: '교정중',
+  //         authorId: user!.id,
+  //       },
+  //     });
 
-      // when
-      const { status, body } = await request(app.getHttpServer()).get(
-        `/admin/poems/proofreading/${poem.id}`,
-      );
+  //     // when
+  //     const { status, body } = await request(app.getHttpServer()).get(
+  //       `/admin/poems/proofreading/${poem.id}`,
+  //     );
 
-      // then
-      expect(status).toBe(200);
-      expect(body.title).toBe(poem.title);
-      expect(body.audioUrl).toBeDefined();
-    });
+  //     // then
+  //     expect(status).toBe(200);
+  //     expect(body.title).toBe(poem.title);
+  //     expect(body.audioUrl).toBeDefined();
+  //   });
 
-    it('글감이 오디오일땐 audioUrl을 inspiration에 포함해서 반환한다', async () => {
-      // given
-      const { accessToken, name } = await login(app);
-      const user = await prisma.user.findFirst({
-        where: { name },
-      });
-      const inspiration = await prisma.inspiration.create({
-        data: {
-          type: 'AUDIO',
-          displayName: 'test.mp3',
-        },
-      });
-      const poem = await prisma.poem.create({
-        data: {
-          title: 'test-title',
-          content: 'test-content',
-          themes: ['test-theme'],
-          interactions: ['test-interaction'],
-          textAlign: 'center',
-          textSize: 16,
-          textFont: 'test-font',
-          isRecorded: false,
-          inspirationId: inspiration.id,
-          status: '교정중',
-          authorId: user!.id,
-        },
-      });
+  //   it('글감이 오디오일땐 audioUrl을 inspiration에 포함해서 반환한다', async () => {
+  //     // given
+  //     const { accessToken, name } = await login(app);
+  //     const user = await prisma.user.findFirst({
+  //       where: { name },
+  //     });
+  //     const inspiration = await prisma.inspiration.create({
+  //       data: {
+  //         type: 'AUDIO',
+  //         displayName: 'test.mp3',
+  //       },
+  //     });
+  //     const poem = await prisma.poem.create({
+  //       data: {
+  //         title: 'test-title',
+  //         content: 'test-content',
+  //         themes: ['test-theme'],
+  //         interactions: ['test-interaction'],
+  //         textAlign: 'center',
+  //         textSize: 16,
+  //         textFont: 'test-font',
+  //         isRecorded: false,
+  //         inspirationId: inspiration.id,
+  //         status: '교정중',
+  //         authorId: user!.id,
+  //       },
+  //     });
 
-      // when
-      const { status, body } = await request(app.getHttpServer()).get(
-        `/admin/poems/proofreading/${poem.id}`,
-      );
+  //     // when
+  //     const { status, body } = await request(app.getHttpServer()).get(
+  //       `/admin/poems/proofreading/${poem.id}`,
+  //     );
 
-      // then
-      expect(status).toBe(200);
-      expect(body.title).toBe(poem.title);
-      expect(body.inspiration.audioUrl).toBeDefined();
-    });
-  });
+  //     // then
+  //     expect(status).toBe(200);
+  //     expect(body.title).toBe(poem.title);
+  //     expect(body.inspiration.audioUrl).toBeDefined();
+  //   });
+  // });
 
   describe('PATCH /admin/poems/proofreading/:id/publish - 출판', () => {
     it('시를 출판한다', async () => {


### PR DESCRIPTION
## 🏷️ 연관 이슈
- close #71 

## ✨ 작업 내용
- 기존에 id, title만 반환하던 시 리스트 조회를 필요한 데이터들 다담아서 한번에 반환
- 지금 코드 레전드임
- 관리자쪽 dto, poem repository 쪽 타입, inspiration: {} 안에 넣어주는 데이터들이나 poem의 isRecorded에 따라서 audioUrl을 담아주는 방식에 optional 로 주는지 nullable로 주는지에 대해서 일관성을 전혀 생각하지 않은상태. 나중에 싹 뜯어고쳐야할듯한데 일단은 어떻게든 swagger랑은 매칭시켜둔 상태라 해커톤 단계에선 이대로..