### PR TITLE
[업적] - 목소리의 주인공

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,7 +33,8 @@ model User {
   poems             Poem[]
   achievements      AchievementAcquisition[]
   scraps            Scrap[]
-  EmotionSelection  EmotionSelection[]
+  emotionSelections EmotionSelection[]
+  userAccessDates   UserAccessHistory[]
 
   @@unique([provider, providerId])
 }
@@ -110,4 +111,13 @@ model EmotionSelection {
   user User @relation(fields: [userId], references: [id])
 
   @@id([userId, emotion])
+}
+
+model UserAccessHistory {
+  userId String
+  date   DateTime @default(now()) @db.Date
+
+  user User @relation(fields: [userId], references: [id])
+
+  @@id([userId, date])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -90,6 +90,8 @@ model AchievementAcquisition {
   user          User        @relation(fields: [userId], references: [id])
   achievementId String
   achievement   Achievement @relation(fields: [achievementId], references: [id])
+
+  @@unique([userId, achievementId])
 }
 
 model Inspiration {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,6 +55,8 @@ model Poem {
 
   createdAt DateTime @default(now())
 
+  playCount Int @default(0)
+
   inspirationId String
   inspiration   Inspiration @relation(fields: [inspirationId], references: [id], onDelete: NoAction)
   authorId      String

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,7 @@ model User {
   poems             Poem[]
   achievements      AchievementAcquisition[]
   scraps            Scrap[]
+  EmotionSelection  EmotionSelection[]
 
   @@unique([provider, providerId])
 }
@@ -98,4 +99,13 @@ model Inspiration {
   poems       Poem[]
 
   @@unique([type, displayName])
+}
+
+model EmotionSelection {
+  userId  String
+  emotion String
+
+  user User @relation(fields: [userId], references: [id])
+
+  @@id([userId, emotion])
 }

--- a/src/achievement/achievement.module.ts
+++ b/src/achievement/achievement.module.ts
@@ -15,5 +15,6 @@ import { UserPrismaRepository } from '../user/user.prisma.repository';
     { provide: AchievementRepository, useClass: AchievementPrismaRepository },
     { provide: UserRepository, useClass: UserPrismaRepository },
   ],
+  exports: [AchievementRepository],
 })
 export class AchievementModule {}

--- a/src/achievement/achievement.repository.ts
+++ b/src/achievement/achievement.repository.ts
@@ -1,6 +1,7 @@
 export interface AchievementRepository {
   findAll(): Promise<Achievement[]>;
   findAllByUserId(userId: string): Promise<Achievement[]>;
+  acquire(userId: string, achievementName: string): Promise<void>;
 }
 
 type Achievement = {

--- a/src/emotion/dto/request/emotion-select.dto.ts
+++ b/src/emotion/dto/request/emotion-select.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum } from 'class-validator';
+import { emotions } from 'src/constants/emotions';
+
+const emotionList = emotions.map((item) => item.emotion);
+
+export class EmotionSelectDto {
+  @ApiProperty({
+    enum: emotionList,
+    description: '"모르겠음" 감정을 선택했을 땐 요청안하시면 됩니다.',
+  })
+  @IsEnum(emotionList)
+  emotion: (typeof emotionList)[number];
+}

--- a/src/emotion/dto/request/index.ts
+++ b/src/emotion/dto/request/index.ts
@@ -1,0 +1,1 @@
+export * from './emotion-select.dto';

--- a/src/emotion/emotion.controller.ts
+++ b/src/emotion/emotion.controller.ts
@@ -22,7 +22,7 @@ export class EmotionController {
   @ApiResponse({ status: 200, type: [EmotionDto] })
   @Get()
   async getAll(@CurrentUser() userId: string) {
-    return this.emotionService.getAll(userId);
+    return await this.emotionService.getAll(userId);
   }
 
   @ApiOperation({ summary: '감정 선택했을 때 내역 저장하는 API' })
@@ -32,6 +32,6 @@ export class EmotionController {
     @Body() { emotion }: EmotionSelectDto,
     @CurrentUser() userId: string,
   ) {
-    return this.emotionService.select(userId, emotion);
+    return await this.emotionService.select(userId, emotion);
   }
 }

--- a/src/emotion/emotion.controller.ts
+++ b/src/emotion/emotion.controller.ts
@@ -1,9 +1,19 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Post, Body, UseGuards } from '@nestjs/common';
 import { EmotionService } from './emotion.service';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
 import { EmotionDto } from './dto/response';
+import { EmotionSelectDto } from './dto/request';
+import { JwtGuard } from 'src/auth/guards';
+import { CurrentUser } from 'src/common/decorators';
 
 @ApiTags('emotions')
+@ApiBearerAuth()
+@UseGuards(JwtGuard)
 @Controller('emotions')
 export class EmotionController {
   constructor(private readonly emotionService: EmotionService) {}
@@ -13,5 +23,15 @@ export class EmotionController {
   @Get()
   async getAll() {
     return this.emotionService.getAll();
+  }
+
+  @ApiOperation({ summary: '감정 선택했을 때 내역 저장하는 API' })
+  @ApiResponse({ status: 201 })
+  @Post('select')
+  async select(
+    @Body() { emotion }: EmotionSelectDto,
+    @CurrentUser() userId: string,
+  ) {
+    return this.emotionService.select(userId, emotion);
   }
 }

--- a/src/emotion/emotion.controller.ts
+++ b/src/emotion/emotion.controller.ts
@@ -21,8 +21,8 @@ export class EmotionController {
   @ApiOperation({ summary: '감정 리스트 조회' })
   @ApiResponse({ status: 200, type: [EmotionDto] })
   @Get()
-  async getAll() {
-    return this.emotionService.getAll();
+  async getAll(@CurrentUser() userId: string) {
+    return this.emotionService.getAll(userId);
   }
 
   @ApiOperation({ summary: '감정 선택했을 때 내역 저장하는 API' })

--- a/src/emotion/emotion.module.ts
+++ b/src/emotion/emotion.module.ts
@@ -4,9 +4,10 @@ import { EmotionService } from './emotion.service';
 import { EmotionRepository } from './emotion.repository';
 import { EmotionPrismaRepository } from './emotion.prisma.repository';
 import { AchievementModule } from 'src/achievement/achievement.module';
+import { UserModule } from 'src/user/user.module';
 
 @Module({
-  imports: [AchievementModule],
+  imports: [AchievementModule, UserModule],
   controllers: [EmotionController],
   providers: [
     EmotionService,

--- a/src/emotion/emotion.module.ts
+++ b/src/emotion/emotion.module.ts
@@ -1,9 +1,19 @@
 import { Module } from '@nestjs/common';
 import { EmotionController } from './emotion.controller';
 import { EmotionService } from './emotion.service';
+import { EmotionRepository } from './emotion.repository';
+import { EmotionPrismaRepository } from './emotion.prisma.repository';
+import { AchievementModule } from 'src/achievement/achievement.module';
 
 @Module({
+  imports: [AchievementModule],
   controllers: [EmotionController],
-  providers: [EmotionService],
+  providers: [
+    EmotionService,
+    {
+      provide: EmotionRepository,
+      useClass: EmotionPrismaRepository,
+    },
+  ],
 })
 export class EmotionModule {}

--- a/src/emotion/emotion.prisma.repository.ts
+++ b/src/emotion/emotion.prisma.repository.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { EmotionRepository } from './emotion.repository';
+import { Prisma } from '@prisma/client';
+
+@Injectable()
+export class EmotionPrismaRepository implements EmotionRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async createSelection(userId: string, emotion: string): Promise<void> {
+    try {
+      await this.prisma.emotionSelection.create({
+        data: {
+          userId,
+          emotion,
+        },
+      });
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2002'
+      ) {
+        return;
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  async CountSelection(userId: string): Promise<number> {
+    return await this.prisma.emotionSelection.count({
+      where: {
+        userId,
+      },
+    });
+  }
+}

--- a/src/emotion/emotion.repository.ts
+++ b/src/emotion/emotion.repository.ts
@@ -1,0 +1,6 @@
+export interface EmotionRepository {
+  createSelection(userId: string, emotion: string): Promise<void>;
+  CountSelection(userId: string): Promise<number>;
+}
+
+export const EmotionRepository = Symbol('EmotionRepository');

--- a/src/emotion/emotion.service.ts
+++ b/src/emotion/emotion.service.ts
@@ -1,9 +1,26 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Inject } from '@nestjs/common';
 import { emotions } from '../constants/emotions';
+import { EmotionRepository } from './emotion.repository';
+import { AchievementRepository } from 'src/achievement/achievement.repository';
 
 @Injectable()
 export class EmotionService {
+  constructor(
+    @Inject(EmotionRepository)
+    private readonly emotionRepository: EmotionRepository,
+    @Inject(AchievementRepository)
+    private readonly achievementRepository: AchievementRepository,
+  ) {}
   getAll() {
     return emotions;
+  }
+
+  async select(userId: string, emotion: string) {
+    await this.emotionRepository.createSelection(userId, emotion);
+    const count = await this.emotionRepository.CountSelection(userId);
+    if (count >= emotions.length) {
+      await this.achievementRepository.acquire(userId, '들쑥날쑥');
+    }
+    return;
   }
 }

--- a/src/emotion/emotion.service.ts
+++ b/src/emotion/emotion.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Inject } from '@nestjs/common';
 import { emotions } from '../constants/emotions';
 import { EmotionRepository } from './emotion.repository';
 import { AchievementRepository } from 'src/achievement/achievement.repository';
+import { UserRepository } from 'src/user/user.repository';
 
 @Injectable()
 export class EmotionService {
@@ -10,11 +11,21 @@ export class EmotionService {
     private readonly emotionRepository: EmotionRepository,
     @Inject(AchievementRepository)
     private readonly achievementRepository: AchievementRepository,
+    @Inject(UserRepository)
+    private readonly userRepository: UserRepository,
   ) {}
-  getAll() {
+  // 매일 그대와 업적 획득 로직 포함
+  async getAll(userId: string) {
+    await this.userRepository.createAccessHistory(userId);
+    const count =
+      await this.userRepository.countAccessHistoryRecentTenDays(userId);
+    if (count >= 10) {
+      await this.achievementRepository.acquire(userId, '매일 그대와');
+    }
     return emotions;
   }
 
+  // 들쑥날쑥 업적 획득로직 포함
   async select(userId: string, emotion: string) {
     await this.emotionRepository.createSelection(userId, emotion);
     const count = await this.emotionRepository.CountSelection(userId);

--- a/src/poem/dto/request/index.ts
+++ b/src/poem/dto/request/index.ts
@@ -2,3 +2,4 @@ export * from './analyze-poem.dto';
 export * from './update-tag.dto';
 export * from './create-poem.dto';
 export * from './get-poems.dto';
+export * from './play.dto';

--- a/src/poem/dto/request/play.dto.ts
+++ b/src/poem/dto/request/play.dto.ts
@@ -1,0 +1,6 @@
+import { IsUUID } from 'class-validator';
+
+export class PlayDto {
+  @IsUUID()
+  id: string;
+}

--- a/src/poem/poem.controller.ts
+++ b/src/poem/poem.controller.ts
@@ -135,7 +135,10 @@ export class PoemController {
   }
 
   @ApiOperation({ summary: '낭독 오디오 플레이' })
-  @ApiResponse({ status: 200 })
+  @ApiResponse({
+    status: 200,
+    description: '낭독 횟수 증가, responsebody는 없습니다.',
+  })
   @Get(':id/play')
   async play(@Param() { id }: PlayDto) {
     await this.poemService.play(id);

--- a/src/poem/poem.controller.ts
+++ b/src/poem/poem.controller.ts
@@ -27,6 +27,7 @@ import {
   UpdateTagDto,
   CreatePoemDto,
   GetPoemsDto,
+  PlayDto,
 } from './dto/request';
 import { TagsDto, ContentDto, NewPoemDto, PoemDto } from './dto/response';
 import { PoemService } from './poem.service';
@@ -131,5 +132,13 @@ export class PoemController {
     @CurrentUser() userId: string,
   ): Promise<PoemDto[]> {
     return await this.poemService.getThree({ emotion, index, userId });
+  }
+
+  @ApiOperation({ summary: '낭독 오디오 플레이' })
+  @ApiResponse({ status: 200 })
+  @Get(':id/play')
+  async play(@Param() { id }: PlayDto) {
+    await this.poemService.play(id);
+    return;
   }
 }

--- a/src/poem/poem.module.ts
+++ b/src/poem/poem.module.ts
@@ -8,9 +8,10 @@ import { AwsModule } from '../aws/aws.module';
 import { ScrapRepository } from './scrap.repository';
 import { ScrapPrismaRepository } from './scrap.prisma.repository';
 import { TagModule } from 'src/tag/tag.module';
+import { AchievementModule } from 'src/achievement/achievement.module';
 
 @Module({
-  imports: [AwsModule, TagModule],
+  imports: [AwsModule, TagModule, AchievementModule],
   controllers: [PoemController],
   providers: [
     PoemService,

--- a/src/poem/poem.prisma.repository.ts
+++ b/src/poem/poem.prisma.repository.ts
@@ -77,15 +77,18 @@ export class PoemPrismaRepository implements PoemRepository {
   }
 
   async updateStatus(id: string, status: string) {
-    await this.prisma.poem.update({
+    const { authorId } = await this.prisma.poem.update({
       where: {
         id,
       },
       data: {
         status,
       },
+      select: {
+        authorId: true,
+      },
     });
-    return;
+    return { authorId };
   }
 
   async findThreeByIndex({ userId, index }: FindInputWithoutEmotion) {
@@ -166,6 +169,15 @@ export class PoemPrismaRepository implements PoemRepository {
             id: true,
           },
         },
+      },
+    });
+  }
+
+  async countPublishedByUserId(userId: string) {
+    return this.prisma.poem.count({
+      where: {
+        authorId: userId,
+        status: '출판',
       },
     });
   }

--- a/src/poem/poem.prisma.repository.ts
+++ b/src/poem/poem.prisma.repository.ts
@@ -15,6 +15,7 @@ export class PoemPrismaRepository implements PoemRepository {
       omit: {
         originalContent: true,
         originalTitle: true,
+        playCount: true,
       },
     });
   }
@@ -178,6 +179,23 @@ export class PoemPrismaRepository implements PoemRepository {
       where: {
         authorId: userId,
         status: '출판',
+      },
+    });
+  }
+
+  async increasePlayCount(id: string) {
+    return await this.prisma.poem.update({
+      where: {
+        id,
+      },
+      data: {
+        playCount: {
+          increment: 1,
+        },
+      },
+      select: {
+        authorId: true,
+        playCount: true,
       },
     });
   }

--- a/src/poem/poem.repository.ts
+++ b/src/poem/poem.repository.ts
@@ -5,9 +5,10 @@ export interface PoemRepository {
   countUserDaily(userId: string): Promise<number>;
   findAllProofreading(): Promise<ProofreadingPoemList>;
   findOneProofreading(id: string): Promise<PoemWithOriginalContent | null>;
-  updateStatus(id: string, status: string): Promise<void>;
+  updateStatus(id: string, status: string): Promise<{ authorId: string }>;
   findThreeByIndex(findInputWithoutTags: FindInputWithoutTags): Promise<Poem[]>;
   findNByTagAndIndex(findInputWithTags: FindInputWithTags): Promise<Poem[]>;
+  countPublishedByUserId(userId: string): Promise<number>;
 }
 
 export type CreateInput = {

--- a/src/poem/poem.repository.ts
+++ b/src/poem/poem.repository.ts
@@ -9,6 +9,9 @@ export interface PoemRepository {
   findThreeByIndex(findInputWithoutTags: FindInputWithoutTags): Promise<Poem[]>;
   findNByTagAndIndex(findInputWithTags: FindInputWithTags): Promise<Poem[]>;
   countPublishedByUserId(userId: string): Promise<number>;
+  increasePlayCount(
+    id: string,
+  ): Promise<{ authorId: string; playCount: number }>;
 }
 
 export type CreateInput = {

--- a/src/poem/poem.service.ts
+++ b/src/poem/poem.service.ts
@@ -226,6 +226,15 @@ export class PoemService {
       };
     });
   }
+
+  async play(id: string) {
+    const { authorId, playCount } =
+      await this.poemRepository.increasePlayCount(id);
+    if (playCount === 30) {
+      await this.achievementRepository.acquire(authorId, '목소리의 주인공');
+    }
+    return;
+  }
 }
 
 export type CreateInput = {

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -27,6 +27,9 @@ export interface UserRepository {
     name: string;
   }>;
   update(userId: string, data: UpdateUserData): Promise<void>;
+
+  createAccessHistory(userId: string): Promise<void>;
+  countAccessHistoryRecentTenDays(userId: string, date?: Date): Promise<number>;
 }
 
 type Achievement = {


### PR DESCRIPTION
## 🏷️ 연관 이슈
- close #63 
- 먼저 Merge 되야 하는 PR: #79 , #80 
## ✨ 작업 내용
- 목소리의 주인공 업적 획득
- GET /poems/:id/play API 추가
- Poem Schema에 playCount 추가
- api가 호출될때마다 playCount += 1 씩 하며 playCount === 30 일때 업적 획득
- E2E Test
  - 오디오가 한 번 플레이되면 데이터베이스에 playCount가 1이 된다
  - 오디오가 30회 플레이되면 목소리의 주인공 업적을 획득한다