### PR TITLE
출판할때 author의 ink를 10 증가시킨다.

### DIFF
--- a/src/poem/poem.prisma.repository.ts
+++ b/src/poem/poem.prisma.repository.ts
@@ -77,13 +77,22 @@ export class PoemPrismaRepository implements PoemRepository {
     });
   }
 
-  async updateStatus(id: string, status: string) {
+  async updateToPublishedStatus(id: string, ink: number) {
     const { authorId } = await this.prisma.poem.update({
       where: {
         id,
       },
       data: {
-        status,
+        status: '출판',
+        author: {
+          update: {
+            data: {
+              ink: {
+                increment: ink,
+              },
+            },
+          },
+        },
       },
       select: {
         authorId: true,

--- a/src/poem/poem.repository.ts
+++ b/src/poem/poem.repository.ts
@@ -5,7 +5,10 @@ export interface PoemRepository {
   countUserDaily(userId: string): Promise<number>;
   findAllProofreading(): Promise<ProofreadingPoemList>;
   findOneProofreading(id: string): Promise<PoemWithOriginalContent | null>;
-  updateStatus(id: string, status: string): Promise<{ authorId: string }>;
+  updateToPublishedStatus(
+    id: string,
+    ink: number,
+  ): Promise<{ authorId: string }>;
   findThreeByIndex(findInputWithoutTags: FindInputWithoutTags): Promise<Poem[]>;
   findNByTagAndIndex(findInputWithTags: FindInputWithTags): Promise<Poem[]>;
   countPublishedByUserId(userId: string): Promise<number>;

--- a/src/poem/poem.service.ts
+++ b/src/poem/poem.service.ts
@@ -178,7 +178,12 @@ export class PoemService {
 
   // 첫 발자국 업적 획득 로직 포함
   async publish(id: string) {
-    const { authorId } = await this.poemRepository.updateStatus(id, '출판');
+    const toAddInk = 10;
+    const { authorId } = await this.poemRepository.updateToPublishedStatus(
+      id,
+      toAddInk,
+    );
+
     const publishedCount =
       await this.poemRepository.countPublishedByUserId(authorId);
     if (publishedCount === 1) {

--- a/test/e2e/admin.e2e-spec.ts
+++ b/test/e2e/admin.e2e-spec.ts
@@ -291,7 +291,7 @@ describe('Admin (e2e)', () => {
   // });
 
   describe('PATCH /admin/poems/proofreading/:id/publish - 출판', () => {
-    it('시를 출판한다', async () => {
+    it('시를 출판하면 ink가 10 추가된다.', async () => {
       // given
       const { accessToken, name } = await login(app);
       const user = await prisma.user.findFirst({
@@ -337,6 +337,10 @@ describe('Admin (e2e)', () => {
         where: { id: poem.id },
       });
       expect(publishedPoem?.status).toBe('출판');
+      const updatedUser = await prisma.user.findFirst({
+        where: { name },
+      });
+      expect(updatedUser?.ink).toBe(10);
     });
 
     it('시를 출판하면 해당 유저는 첫 발자국 업적을 획득한다', async () => {


### PR DESCRIPTION
## 🏷️ 연관 이슈
- close #82 
## ✨ 작업 내용
- 기존에 poem.repository의 메소드 이름이 updateStatus 였는데 출판 시 잉크를 획득하는 쿼리까지 한번에 보내기 위해 updateToPublishedStatus로 이름 변경
- repository에 비즈니스로직이 들어가는 걸 막기 위해 증가시킬 ink를 매개변수로 받음
- 기존 출판 E2E에 잉크획득확인 추가