### PR TITLE
몇 개의 시를 더 쓸 수 있는지 개수 반환

### DIFF
--- a/src/poem/dto/response/index.ts
+++ b/src/poem/dto/response/index.ts
@@ -2,3 +2,4 @@ export * from './tags.dto';
 export * from './content.dto';
 export * from './new-poem.dto';
 export * from './poem.dto';
+export * from './remain-poem-count.dto';

--- a/src/poem/dto/response/remain-poem-count.dto.ts
+++ b/src/poem/dto/response/remain-poem-count.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RemainPoemCountDto {
+  @ApiProperty({
+    description: '몇 개의 시를 더 쓸 수 있는지 나타냄',
+    enum: [0, 1, 2],
+  })
+  readonly count: number;
+}

--- a/src/poem/poem.controller.ts
+++ b/src/poem/poem.controller.ts
@@ -9,7 +9,6 @@ import {
   UploadedFile,
   Param,
   Get,
-  HttpException,
   Query,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
@@ -29,7 +28,13 @@ import {
   GetPoemsDto,
   PlayDto,
 } from './dto/request';
-import { TagsDto, ContentDto, NewPoemDto, PoemDto } from './dto/response';
+import {
+  TagsDto,
+  ContentDto,
+  NewPoemDto,
+  PoemDto,
+  RemainPoemCountDto,
+} from './dto/response';
 import { PoemService } from './poem.service';
 import { CurrentUser } from '../common/decorators';
 import { JwtGuard } from '../auth/guards';
@@ -98,24 +103,16 @@ export class PoemController {
   }
 
   @ApiOperation({
-    summary: '시를 쓸 수 있는지 확인하기 - 하루 두 번만 글쓸수있음',
+    summary: '몇 개의 시를 더 쓸 수 있는지 확인하기 - 하루 두 번만 글쓸수있음',
   })
   @ApiResponse({
     status: 200,
-    description: '시를 쓸 수 있음. 따로 응답 body는 없습니다.',
+    type: RemainPoemCountDto,
+    description: '더 쓸 수 있는 시의 개수를 반환합니다. (0, 1, 2)',
   })
-  @ApiResponse({
-    status: 423,
-    description: '하루에 두 번만 작성할 수 있습니다.',
-  })
-  @Get('can-write')
-  async canWrite(@CurrentUser() userId: string) {
-    const result = await this.poemService.canWrite(userId);
-    if (result) {
-      return;
-    } else {
-      throw new HttpException('하루에 두 번만 작성할 수 있습니다.', 423);
-    }
+  @Get('remain')
+  async getRemain(@CurrentUser() userId: string): Promise<RemainPoemCountDto> {
+    return await this.poemService.checkRemain(userId);
   }
 
   @ApiOperation({ summary: '알고리즘에 의해 시를 3개씩 반환해줌' })

--- a/src/poem/poem.service.ts
+++ b/src/poem/poem.service.ts
@@ -84,13 +84,12 @@ export class PoemService {
     await this.poemRepository.decreaseScrapCount(poemId);
   }
 
-  async canWrite(userId: string) {
+  async checkRemain(userId: string) {
+    const maximum = 2;
     const count = await this.poemRepository.countUserDaily(userId);
-    if (count < 2) {
-      return true;
-    } else {
-      return false;
-    }
+    return {
+      count: maximum - count,
+    };
   }
 
   async getProofreadingList() {

--- a/test/e2e/poem.e2e-spec.ts
+++ b/test/e2e/poem.e2e-spec.ts
@@ -300,8 +300,8 @@ describe('Poem (e2e)', () => {
     });
   });
 
-  describe('GET /poems/can-write - 시를 쓸 수 있는지 확인', () => {
-    it('이미 시를 두 번 썼을 때 423 에러를 반환한다', async () => {
+  describe('GET /poems/remain - 남은 시 개수 반환', () => {
+    it('이미 시를 두 번 썼을 때 0을 반환한다', async () => {
       // given
       const { accessToken, name } = await login(app);
       const user = await prisma.user.findFirst({
@@ -346,15 +346,16 @@ describe('Poem (e2e)', () => {
       });
 
       // when
-      const { status } = await request(app.getHttpServer())
-        .get('/poems/can-write')
+      const { status, body } = await request(app.getHttpServer())
+        .get('/poems/remain')
         .set('Authorization', `Bearer ${accessToken}`);
 
       // then
-      expect(status).toEqual(423);
+      expect(status).toEqual(200);
+      expect(body).toEqual({ count: 0 });
     });
 
-    it('아직 시를 쓰지 않았거나 한 번만 썼을 때 200을 반환한다', async () => {
+    it('시를 한번만 썼을 때 1을 반환한다', async () => {
       // given
       const { accessToken, name } = await login(app);
       const user = await prisma.user.findFirst({
@@ -383,12 +384,13 @@ describe('Poem (e2e)', () => {
       });
 
       // when
-      const { status } = await request(app.getHttpServer())
-        .get('/poems/can-write')
+      const { status, body } = await request(app.getHttpServer())
+        .get('/poems/remain')
         .set('Authorization', `Bearer ${accessToken}`);
 
       // then
       expect(status).toEqual(200);
+      expect(body).toEqual({ count: 1 });
     });
   });
 


### PR DESCRIPTION
## ✨ 작업 내용
- 기존에 글을 더 쓸 수 있는지 없는지 확인만 하는 GET /poems/can-write api를 수정해 GET /poems/remain api로 변경
- 기존에 200/423 응답코드만 보냈던 걸 이제는 200 응답에 반환값으로 0, 1, 2 중에 하나를 반환
