### PR TITLE
fix: 시 리스트 반환할때 index 로직없이 태그만 맞으면 전부 다 반환

### DIFF
--- a/src/poem/dto/request/get-poems.dto.ts
+++ b/src/poem/dto/request/get-poems.dto.ts
@@ -1,11 +1,8 @@
-import { IsNumber, IsOptional, IsEnum } from 'class-validator';
+import { IsOptional, IsEnum } from 'class-validator';
 import { emotions } from 'src/constants/emotions';
 
 export class GetPoemsDto {
   @IsOptional()
   @IsEnum(emotions.map((emotion) => emotion.emotion))
   readonly emotion?: (typeof emotions)[number]['emotion'];
-
-  @IsNumber()
-  readonly index: number;
 }

--- a/src/poem/poem.controller.ts
+++ b/src/poem/poem.controller.ts
@@ -118,20 +118,19 @@ export class PoemController {
     return await this.poemService.getRemain(userId);
   }
 
-  @ApiOperation({ summary: '알고리즘에 의해 시를 3개씩 반환해줌' })
+  @ApiOperation({ summary: '알고리즘에 의해 시를 한번에 다 보내줌' })
   @ApiQuery({
     name: 'emotion',
     required: false,
     description: '기분이 모르겠음 일때는 안보내주시면 됩니다.',
   })
-  @ApiQuery({ name: 'index', required: true, description: '0부터 시작합니다.' })
   @ApiResponse({ status: 200, type: PoemDto, isArray: true })
   @Get()
-  async getThree(
-    @Query() { emotion, index }: GetPoemsDto,
+  async getAllByEmotion(
+    @Query() { emotion }: GetPoemsDto,
     @CurrentUser() userId: string,
   ): Promise<PoemDto[]> {
-    return await this.poemService.getThree({ emotion, index, userId });
+    return await this.poemService.getAllByEmotion({ emotion, userId });
   }
 
   @ApiOperation({ summary: '낭독 오디오 플레이' })

--- a/src/poem/poem.prisma.repository.ts
+++ b/src/poem/poem.prisma.repository.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { PoemRepository, FindInputWithTags } from './poem.repository';
+import { PoemRepository } from './poem.repository';
 import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
@@ -121,98 +121,6 @@ export class PoemPrismaRepository implements PoemRepository {
     return { authorId };
   }
 
-  async findThreeByIndex({ userId, index }: FindInputWithoutEmotion) {
-    return this.prisma.poem.findMany({
-      take: 3,
-      skip: index * 3,
-      orderBy: {
-        createdAt: 'desc',
-      },
-      where: {
-        status: '출판',
-      },
-      select: {
-        id: true,
-        title: true,
-        content: true,
-        textAlign: true,
-        textSize: true,
-        textFont: true,
-        themes: true,
-        interactions: true,
-        isRecorded: true,
-        inspirationId: true,
-        createdAt: true,
-        author: {
-          select: {
-            id: true,
-            name: true,
-          },
-        },
-        scraps: {
-          where: {
-            userId,
-          },
-          select: {
-            id: true,
-          },
-        },
-      },
-    });
-  }
-
-  async findNByTagAndIndex(findInputWithTags: FindInputWithTags) {
-    return this.prisma.poem.findMany({
-      take: findInputWithTags.limit,
-      skip: findInputWithTags.index * findInputWithTags.limit,
-      orderBy: {
-        createdAt: 'desc',
-      },
-      where: {
-        status: '출판',
-        OR: [
-          {
-            themes: {
-              hasSome: findInputWithTags.themes,
-            },
-          },
-          {
-            interactions: {
-              hasSome: findInputWithTags.interactions,
-            },
-          },
-        ],
-      },
-      select: {
-        id: true,
-        title: true,
-        content: true,
-        textAlign: true,
-        textSize: true,
-        textFont: true,
-        themes: true,
-        interactions: true,
-        isRecorded: true,
-        inspirationId: true,
-        createdAt: true,
-        author: {
-          select: {
-            id: true,
-            name: true,
-          },
-        },
-        scraps: {
-          where: {
-            userId: findInputWithTags.userId,
-          },
-          select: {
-            id: true,
-          },
-        },
-      },
-    });
-  }
-
   async countPublishedByUserId(userId: string) {
     return await this.prisma.poem.count({
       where: {
@@ -273,6 +181,98 @@ export class PoemPrismaRepository implements PoemRepository {
     });
 
     return result.scrapCount;
+  }
+
+  async findAllPublished({ userId }: { userId: string }) {
+    return this.prisma.poem.findMany({
+      where: {
+        status: '출판',
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+      select: {
+        id: true,
+        title: true,
+        content: true,
+        textAlign: true,
+        textSize: true,
+        textFont: true,
+        themes: true,
+        interactions: true,
+        isRecorded: true,
+        inspirationId: true,
+        createdAt: true,
+        author: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+        scraps: {
+          where: {
+            userId,
+          },
+          select: {
+            id: true,
+          },
+        },
+      },
+    });
+  }
+
+  async findAllPublishedByTag(findInput: {
+    userId: string;
+    themes: string[];
+    interactions: string[];
+  }) {
+    return this.prisma.poem.findMany({
+      where: {
+        status: '출판',
+        OR: [
+          {
+            themes: {
+              hasSome: findInput.themes,
+            },
+          },
+          {
+            interactions: {
+              hasSome: findInput.interactions,
+            },
+          },
+        ],
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+      select: {
+        id: true,
+        title: true,
+        content: true,
+        textAlign: true,
+        textSize: true,
+        textFont: true,
+        themes: true,
+        interactions: true,
+        isRecorded: true,
+        inspirationId: true,
+        createdAt: true,
+        author: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+        scraps: {
+          where: {
+            userId: findInput.userId,
+          },
+          select: {
+            id: true,
+          },
+        },
+      },
+    });
   }
 }
 

--- a/src/poem/poem.repository.ts
+++ b/src/poem/poem.repository.ts
@@ -12,8 +12,6 @@ export interface PoemRepository {
     id: string,
     ink: number,
   ): Promise<{ authorId: string }>;
-  findThreeByIndex(findInputWithoutTags: FindInputWithoutTags): Promise<Poem[]>;
-  findNByTagAndIndex(findInputWithTags: FindInputWithTags): Promise<Poem[]>;
   increasePlayCount(
     id: string,
   ): Promise<{ authorId: string; playCount: number }>;
@@ -21,6 +19,8 @@ export interface PoemRepository {
   decreaseScrapCount(id: string): Promise<number>;
   countUserDaily(userId: string): Promise<number>;
   countPublishedByUserId(userId: string): Promise<number>;
+  findAllPublishedByTag(findInputWithTags: FindInputWithTags): Promise<Poem[]>;
+  findAllPublished(findInputWithoutTags: FindInputWithoutTags): Promise<Poem[]>;
 }
 
 export type CreateInput = {
@@ -97,13 +97,10 @@ export type Poem = {
 
 export type FindInputWithoutTags = {
   userId: string;
-  index: number;
 };
 
 export type FindInputWithTags = {
   userId: string;
-  index: number;
-  limit: number;
   themes: (typeof themes)[number][];
   interactions: (typeof interactions)[number][];
 };

--- a/src/poem/poem.service.ts
+++ b/src/poem/poem.service.ts
@@ -213,31 +213,22 @@ export class PoemService {
     return;
   }
 
-  async getThree(getPoemsInput: GetPoemsInput) {
-    let poems = [];
+  async getAllByEmotion(getPoemsInput: GetPoemsInput) {
+    let poems;
     if (getPoemsInput.emotion) {
-      const tempPoems = [];
       const firstTags = this.tagService.getFirstTags(getPoemsInput.emotion);
       const secondTags = this.tagService.getSecondTags(getPoemsInput.emotion);
-      tempPoems.push(
-        await this.poemRepository.findNByTagAndIndex({
-          ...getPoemsInput,
-          ...firstTags,
-          limit: 2,
-        }),
-      );
-      tempPoems.push(
-        await this.poemRepository.findNByTagAndIndex({
-          ...getPoemsInput,
-          ...secondTags,
-          limit: 1,
-        }),
-      );
-      poems = tempPoems.flat();
-    } else {
-      poems = await this.poemRepository.findThreeByIndex({
+      const allTags = {
+        themes: [...firstTags.themes, ...secondTags.themes],
+        interactions: [...firstTags.interactions, ...secondTags.interactions],
+      };
+      poems = await this.poemRepository.findAllPublishedByTag({
         userId: getPoemsInput.userId,
-        index: getPoemsInput.index,
+        ...allTags,
+      });
+    } else {
+      poems = await this.poemRepository.findAllPublished({
+        userId: getPoemsInput.userId,
       });
     }
 
@@ -289,5 +280,4 @@ export type UpdateTagInput = {
 export type GetPoemsInput = {
   userId: string;
   emotion?: (typeof emotions)[number]['emotion'];
-  index: number;
 };

--- a/test/e2e/poem.e2e-spec.ts
+++ b/test/e2e/poem.e2e-spec.ts
@@ -557,7 +557,7 @@ describe('Poem (e2e)', () => {
     });
   });
 
-  describe('GET /poems?emotion&index - 감정별 시 목록 조회', () => {
+  describe('GET /poems?emotion - 감정별 시 목록 조회', () => {
     it('감정이 없을 때도 시를 3개씩 받을 수 있고, 상태가 출판 인 시만 반환한다', async () => {
       // given
       const { accessToken, name } = await login(app);
@@ -754,7 +754,6 @@ describe('Poem (e2e)', () => {
       // then
       expect(status).toEqual(200);
       expect(body).toHaveLength(3);
-      expect(body[2].title).toEqual('테마가 가족');
     });
 
     it('시가 있더라도 감정에 맞는 시가 없을 때는 빈 배열을 반환한다', async () => {


### PR DESCRIPTION
## ✨ 작업 내용
- 기존에 뭐 findN이라던가 index 값받아서 skip, take 이런거 다 삭제
- 1차태그 2개당 2차 태그 1개 순서 상관없이 뒤죽박죽 섞어서 다 반환
